### PR TITLE
Fixed write_id coroutine and simplifications

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "*.yaml": "home-assistant"
+    }
+}


### PR DESCRIPTION
Fixed write_id coroutine, removed testing for existing value in sensor, force write to mqtt.
Cleaned up debug logging.
Added missing parameter for mqtt.async_publish calls (hass variable added). This is for 2021.12