### PR TITLE
Fix "Elecric" typo

### DIFF
--- a/custom_components/thermiq/__init__.py
+++ b/custom_components/thermiq/__init__.py
@@ -235,7 +235,7 @@ async def async_setup(hass, config):
                 "Off",
                 "Auto",
                 "Heatpump only",
-                "Elecric only",
+                "Electric only",
                 "Hotwater only",
             ]
             input_initial = None


### PR DESCRIPTION
I spotted this typo in the UI.