### PR TITLE
Fix @asyncio.coroutine deprecation in Python 3.11

### DIFF
--- a/custom_components/thermiq_mqtt/__init__.py
+++ b/custom_components/thermiq_mqtt/__init__.py
@@ -1,7 +1,6 @@
 """Component for ThermIQ-MQTT support."""
 import logging
 from builtins import property
-import asyncio
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -31,8 +30,6 @@ PLATFORMS = [
     "binary_sensor",
 ]
 
-
-@asyncio.coroutine
 async def async_setup(hass, config):
     """Set up HASL integration"""
     _LOGGER.error("Set up ThermIQ-MQTT integration")


### PR DESCRIPTION
Fixes deprecation / removal of generator based decorator related to @asyncio.coroutine.

Solves issue #49