### PR TITLE
Fix 3 critical bugs: device_class, binary sensor, migration + dead code cleanup

### DIFF
--- a/custom_components/thermiq_mqtt/__init__.py
+++ b/custom_components/thermiq_mqtt/__init__.py
@@ -212,7 +212,7 @@ async def _migrate_celsius(hass: HomeAssistant, recorder, entity_id: str, decima
             return False
 
     try:
-        result = recorder.async_add_executor_job(_update_celsius)
+        result = await recorder.async_add_executor_job(_update_celsius)
         return result
     except Exception as e:
         _LOGGER.error("Could not update celsius for %s: %s", entity_id, str(e), exc_info=True)

--- a/custom_components/thermiq_mqtt/binary_sensor.py
+++ b/custom_components/thermiq_mqtt/binary_sensor.py
@@ -44,7 +44,6 @@ from .heatpump.thermiq_regs import (
 )
 
 
-from functools import cached_property
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -164,9 +163,9 @@ class HeatPumpBinarySensor(BinarySensorEntity):
         """Return the device class of the sensor."""
         return self._vp_reg
 
-    @cached_property
+    @property
     def is_on(self) -> bool:
-        return (self._state==True)
+        return self._state is True
 
     @property
     def sorter(self):
@@ -211,7 +210,3 @@ class HeatPumpBinarySensor(BinarySensorEntity):
             self.async_schedule_update_ha_state()
             _LOGGER.debug("async_update_ha: %s: [%s]",self._idx, str(bool_state))
 
-    @property
-    def device_class(self):
-        """Return the class of this device."""
-        return f"{DOMAIN}_HeatPumpSensor"

--- a/custom_components/thermiq_mqtt/heatpump/__init__.py
+++ b/custom_components/thermiq_mqtt/heatpump/__init__.py
@@ -182,61 +182,28 @@ class HeatPump:
                                     )
                                 )
 
-                # Do some post processing of data received
+                # Do some post processing of data received (outside the for loop)
                 self._hpstate["r01"] = self._hpstate["r01"] + self._hpstate["r02"] / 10
-
-                # self._hass.states.async_set(
-                #     self._domain + "_" + self._id + "." + self._id_reg["r01"],
-                #     self._hpstate["r01"],
-                # )
-
                 self._hpstate["r03"] = self._hpstate["r03"] + self._hpstate["r04"] / 10
-                # self._hass.states.async_set(
-                #     self._domain + "_" + self._id + "." + self._id_reg["r03"],
-                #     self._hpstate["r03"],
-                # )
 
                 self._hpstate["mqtt_counter"] += 1
 
                 if "time" in json_dict:
                     self._hpstate["time_str"] = json_dict["time"]
-                    # self._hass.states.async_set(
-                    #     self._domain + "_" + self._id + ".time_str", json_dict["time"]
-                    # )
                 elif "Time" in json_dict:
                     self._hpstate["time_str"] = json_dict["Time"]
-                    # self._hass.states.async_set(
-                    #     self._domain + "_" + self._id + ".time_str", json_dict["Time"]
-                    # )
 
                 if "vp_read" in json_dict:
                     self._hpstate["communication_status"] = json_dict["vp_read"]
-
-                    # self._hass.states.async_set(
-                    #     self._domain
-                    #     + "_"
-                    #     + self._id
-                    #     + ".heatpump_communication_status",
-                    #     json_dict["vp_read"],
-                    # )
                 else:
                     self._hpstate["communication_status"] = "Ok"
-                    # self._hass.states.async_set(
-                    #     self._domain
-                    #     + "_"
-                    #     + self._id
-                    #     + ".heatpump_communication_status",
-                    #     "ok",
-                    # )
 
                 if "app_info" in json_dict:
                     self._hpstate["app_info"] = json_dict["app_info"]
 
-
                 self._hass.bus.fire(
                     self._domain + "_" + self._id + "_msg_rec_event", {}
                 )
-
             else:
                 _LOGGER.error("JSON result was not from ThermIQ-mqtt")
         except ValueError:

--- a/custom_components/thermiq_mqtt/sensor.py
+++ b/custom_components/thermiq_mqtt/sensor.py
@@ -249,7 +249,3 @@ class HeatPumpSensor(SensorEntity):
             self.async_schedule_update_ha_state()
             _LOGGER.debug("async_update_ha: %s", str(state))
 
-    @property
-    def device_class(self):
-        """Return the class of this device."""
-        return f"{DOMAIN}_HeatPumpSensor"


### PR DESCRIPTION
## Summary

Fixes 3 critical bugs identified in #74, plus dead code cleanup:

- **Dead commented-out code removed** — cleaned up commented-out `async_set` calls around the r01/r03 temperature post-processing and other sections. ~~Previously reported as a loop placement bug, but the post-processing was already correctly placed outside the `for k in json_dict` loop.~~ No functional change.
- **`device_class` property overriding valid `_attr_device_class`** — returned `"thermiq_mqtt_HeatPumpSensor"` (invalid), shadowing the correct `SensorDeviceClass.TEMPERATURE` etc. set in `__init__`. Removed the property so `_attr_device_class` works as intended. Fixes #72.
- **Binary sensor `is_on` never updating** — `@cached_property` computes once and caches permanently. Changed to `@property` so MQTT state changes are reflected.
- **DB migration not awaited** — `recorder.async_add_executor_job(_update_celsius)` was missing `await`, so the migration silently did nothing.

## Correction

The original report claimed temperature values were corrupted by post-processing being inside the for loop. On re-inspection, the indentation shows the post-processing (lines 185-197) was already at the same level as the `for` statement (line 73) — i.e., **outside the loop**. The change in `heatpump/__init__.py` is dead code removal only, not a bug fix.

## Changes

| File | Change |
|---|---|
| `heatpump/__init__.py` | Remove dead commented-out code (no functional change) |
| `sensor.py` | Remove invalid `device_class` property |
| `binary_sensor.py` | Remove invalid `device_class` property, `@cached_property` → `@property`, remove unused import |
| `__init__.py` | Add `await` to migration job |

## Test plan

- [ ] Verify sensor entities show correct device classes (e.g. `temperature` for temp sensors)
- [ ] Verify binary sensors update state on MQTT messages
- [ ] Verify DB migration runs on upgrade (check logs for migration messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)