### PR TITLE
Replace input_* platform hijacking with proper Number/Select/Switch entities

### DIFF
--- a/custom_components/thermiq_mqtt/__init__.py
+++ b/custom_components/thermiq_mqtt/__init__.py
@@ -33,17 +33,15 @@ from .heatpump.thermiq_regs import (
     reg_id,
 )
 
-# from .automation import setup_automations
-from .input_number import setup_input_numbers
-from .input_select import setup_input_selects
-from .input_boolean import setup_input_booleans
-
 _LOGGER = logging.getLogger(__name__)
 SERVICE_SET_VALUE = "set_value"
 
 PLATFORMS = [
     "sensor",
     "binary_sensor",
+    "number",
+    "select",
+    "switch",
 ]
 
 async def async_setup(hass, config):
@@ -518,16 +516,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Make config reload
     rld = entry.add_update_listener(reload_entry)
     entry.async_on_unload(rld)
-    hass.async_create_task(setup_input_numbers(heatpump))
-    hass.async_create_task(setup_input_selects(heatpump))
-    hass.async_create_task(setup_input_booleans(heatpump))
 
-    # Load the platforms for heatpump
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    )
+    # Load all platforms (sensor, binary_sensor, number, select, switch)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Wait for hass to start and then add the input_* entities
+    # Wait for hass to start and then setup MQTT
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, handle_hass_started)
 
     return True
@@ -580,6 +573,10 @@ class ThermIQWorker:
             {"action": "add", "heatpump": config_entry.data[CONF_ID]},
         )
         return heatpump
+
+    def get_entry(self, config_entry: ConfigEntry):
+        """Get heatpump for a config entry."""
+        return self._heatpumps[config_entry.data[CONF_ID]]
 
     def remove_entry(self, config_entry: ConfigEntry):
         """Remove entry."""

--- a/custom_components/thermiq_mqtt/__init__.py
+++ b/custom_components/thermiq_mqtt/__init__.py
@@ -15,7 +15,14 @@ from homeassistant.const import (
 from homeassistant.helpers.recorder import session_scope, get_instance as recorder_get_instance
 from homeassistant.components.recorder.statistics import async_change_statistics_unit
 from homeassistant.helpers import entity_registry as er
-from homeassistant.components.recorder.db_schema import StatisticsMeta, Statistics, StatisticsShortTerm
+from homeassistant.components.recorder.db_schema import (
+    StatisticsMeta,
+    Statistics,
+    StatisticsShortTerm,
+    States,
+    StatesMeta,
+)
+from homeassistant.components import persistent_notification
 
 from .const import (
     DOMAIN,
@@ -530,8 +537,18 @@ async def _async_migrate_entry(hass: HomeAssistant, config_entry) -> bool:
         else:
             _LOGGER.info("State class migrations completed successfully")
 
+        # Run input_* -> number/select/switch platform migration
+        success3 = await async_migrate_input_platforms(hass, config_entry)
 
-        if success1 and success2:
+        if not success3:
+            _LOGGER.error(
+                "Migration of input_* platforms failed - history may remain "
+                "split across the old and new entity ids"
+            )
+        else:
+            _LOGGER.info("input_* platform migration completed successfully")
+
+        if success1 and success2 and success3:
             # Mark migration as complete even if some entities failed
             # (they might not exist yet, or be created later)
             migration_data = {
@@ -549,6 +566,294 @@ async def _async_migrate_entry(hass: HomeAssistant, config_entry) -> bool:
         return True  # Continue setup even if migration fails
 
 
+# ---------------------------------------------------------------------------
+# 3.3.0 platform migration:
+#     input_number.*  -> number.*
+#     input_select.*  -> select.*
+#     input_boolean.* -> switch.*
+#
+# Up to 3.1.x the integration hijacked Home Assistant's own input_* helper
+# platforms. Each helper was built with
+#
+#     config[CONF_ID] = f"{heatpump._domain}_{heatpump._id}_{key}"
+#     entity          = CustomInputNumber.from_yaml(config)
+#
+# giving entity ids of the form
+#
+#     input_number.{DOMAIN}_{id_name}_{key}     on platform "input_number"
+#
+# 3.3.0 replaced these with real NumberEntity/SelectEntity/SwitchEntity on this
+# integration's own platform:
+#
+#     number.{DOMAIN}_{id_name}_{key}           on platform "thermiq_mqtt"
+#     unique_id = "uid-" + entity_id
+#
+# The object_id is identical on both sides; only the domain prefix changes, so
+# the mapping is a pure domain swap with no name matching involved.
+#
+# The entity registry cannot perform this rename for us: an entity_id's domain
+# must match its platform's domain, and the stale rows belong to the input_*
+# integrations rather than to this one. So the recorder rows are repointed
+# directly and the orphaned registry entries are then dropped.
+# ---------------------------------------------------------------------------
+
+PLATFORM_MIGRATION_MAP = {
+    "input_number": "number",
+    "input_select": "select",
+    "input_boolean": "switch",
+}
+
+
+async def async_migrate_input_platforms(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> bool:
+    """
+    Carry history and long-term statistics from the pre-3.3.0 input_* helper
+    entities over to the number/select/switch entities that replaced them, then
+    remove the orphaned input_* registry entries.
+
+    Idempotent: once the old rows are gone the scan finds nothing and returns
+    True immediately, so re-running is harmless.
+
+    Returns:
+        bool: True if migration succeeded or was not needed, False on a
+              critical failure. Per-entity problems are logged and do not fail
+              the migration as a whole.
+    """
+    id_name = config_entry.data[CONF_ID]
+    entity_reg = er.async_get(hass)
+    recorder = recorder_get_instance(hass)
+
+    prefixes = {
+        f"{old_domain}.{DOMAIN}_{id_name}_": new_domain
+        for old_domain, new_domain in PLATFORM_MIGRATION_MAP.items()
+    }
+
+    old_entity_ids: set[str] = set()
+
+    # 1. Entities visible in the registry.
+    for entry in list(entity_reg.entities.values()):
+        if any(entry.entity_id.startswith(p) for p in prefixes):
+            old_entity_ids.add(entry.entity_id)
+
+    # 2. Recorder-only orphans. A helper created without a unique_id never
+    #    entered the registry, yet still owns states_meta rows holding its
+    #    history - upstream's input_boolean.py is exactly this case, its
+    #    unique_id registration being commented out. Without this pass their
+    #    history would be silently left behind.
+    try:
+        orphans = await recorder.async_add_executor_job(
+            _discover_recorder_entities, hass, tuple(prefixes)
+        )
+        old_entity_ids.update(orphans)
+    except Exception as e:  # noqa: BLE001 - discovery must not block setup
+        _LOGGER.warning(
+            "Could not scan recorder for orphaned input_* entities: %s", str(e)
+        )
+
+    if not old_entity_ids:
+        _LOGGER.debug(
+            "No pre-3.3.0 input_* entities found for ThermIQ [%s], nothing to migrate",
+            id_name,
+        )
+        return True
+
+    renames: list[tuple[str, str]] = []
+    for old_entity_id in sorted(old_entity_ids):
+        old_domain, object_id = old_entity_id.split(".", 1)
+        new_domain = PLATFORM_MIGRATION_MAP[old_domain]
+        renames.append((old_entity_id, f"{new_domain}.{object_id}"))
+
+    _LOGGER.info(
+        "Migrating %s pre-3.3.0 input_* entities for ThermIQ [%s] to number/select/switch",
+        len(renames),
+        id_name,
+    )
+
+    try:
+        migrated = await recorder.async_add_executor_job(
+            _migrate_recorder_rows, hass, renames
+        )
+    except Exception as e:  # noqa: BLE001 - migration must never block setup
+        _LOGGER.error(
+            "Could not migrate recorder rows for ThermIQ [%s]: %s",
+            id_name,
+            str(e),
+            exc_info=True,
+        )
+        return False
+
+    # Drop the orphaned registry entries only after the recorder rows have been
+    # repointed - otherwise a failure above would strand the history under an
+    # entity_id with no registry entry left to find it by.
+    removed = 0
+    for old_entity_id, _new_entity_id in renames:
+        if entity_reg.async_get(old_entity_id) is None:
+            continue
+        try:
+            entity_reg.async_remove(old_entity_id)
+            removed += 1
+        except Exception as e:  # noqa: BLE001
+            _LOGGER.warning(
+                "Could not remove stale registry entry %s: %s", old_entity_id, str(e)
+            )
+
+    _LOGGER.info(
+        "ThermIQ [%s]: repointed %s recorder entities, removed %s stale registry entries",
+        id_name,
+        migrated,
+        removed,
+    )
+
+    _notify_entity_id_changes(hass, id_name, renames)
+    return True
+
+
+def _discover_recorder_entities(
+    hass: HomeAssistant, prefixes: tuple[str, ...]
+) -> list[str]:
+    """
+    Find entity_ids in states_meta matching any of the old input_* prefixes.
+
+    Filtering happens in Python rather than via SQL LIKE on purpose: an
+    entity_id prefix such as "input_number.thermiq_mqtt_myhp_" is full of
+    underscores, and LIKE treats "_" as a single-character wildcard, so the
+    pattern would match far more than intended. states_meta holds one row per
+    entity, so reading the id column is cheap.
+
+    Runs inside a recorder executor job.
+    """
+    with session_scope(hass=hass, read_only=True) as session:
+        all_ids = session.execute(select(StatesMeta.entity_id)).scalars().all()
+
+    return [eid for eid in all_ids if any(eid.startswith(p) for p in prefixes)]
+
+
+def _migrate_recorder_rows(hass: HomeAssistant, renames: list[tuple[str, str]]) -> int:
+    """
+    Repoint recorder rows from the old entity_ids onto the new ones.
+
+    Two cases per entity:
+
+    * new row absent  - the states_meta/statistics_meta row is renamed in
+      place, carrying all of its history with it.
+    * new row present - the user already ran 3.3.0, so history is split across
+      two rows. The old rows' data is repointed onto the new metadata_id and
+      the emptied old row deleted, merging the two series.
+
+    Runs inside a recorder executor job, opening its own session as the other
+    migrations in this module do.
+
+    Returns the number of entities that had at least one row migrated.
+    """
+    migrated = 0
+
+    with session_scope(hass=hass, read_only=False) as session:
+        for old_entity_id, new_entity_id in renames:
+            touched = False
+
+            # --- recorded states -------------------------------------------
+            old_meta = session.execute(
+                select(StatesMeta).where(StatesMeta.entity_id == old_entity_id)
+            ).scalar_one_or_none()
+
+            if old_meta is not None:
+                new_meta = session.execute(
+                    select(StatesMeta).where(StatesMeta.entity_id == new_entity_id)
+                ).scalar_one_or_none()
+
+                if new_meta is None:
+                    session.execute(
+                        update(StatesMeta)
+                        .where(StatesMeta.metadata_id == old_meta.metadata_id)
+                        .values(entity_id=new_entity_id)
+                    )
+                    _LOGGER.debug(
+                        "Renamed states %s -> %s", old_entity_id, new_entity_id
+                    )
+                else:
+                    session.execute(
+                        update(States)
+                        .where(States.metadata_id == old_meta.metadata_id)
+                        .values(metadata_id=new_meta.metadata_id)
+                    )
+                    session.delete(old_meta)
+                    _LOGGER.debug(
+                        "Merged states %s into %s", old_entity_id, new_entity_id
+                    )
+                touched = True
+
+            # --- long term statistics --------------------------------------
+            # Normally a no-op: input_number helpers carry no state_class and
+            # so have no long-term statistics. Handled anyway for installs that
+            # added one by hand via customize.
+            old_stat = session.execute(
+                select(StatisticsMeta).where(
+                    StatisticsMeta.statistic_id == old_entity_id
+                )
+            ).scalar_one_or_none()
+
+            if old_stat is not None:
+                new_stat = session.execute(
+                    select(StatisticsMeta).where(
+                        StatisticsMeta.statistic_id == new_entity_id
+                    )
+                ).scalar_one_or_none()
+
+                if new_stat is None:
+                    session.execute(
+                        update(StatisticsMeta)
+                        .where(StatisticsMeta.id == old_stat.id)
+                        .values(statistic_id=new_entity_id)
+                    )
+                    _LOGGER.debug(
+                        "Renamed statistics %s -> %s", old_entity_id, new_entity_id
+                    )
+                else:
+                    for table in (Statistics, StatisticsShortTerm):
+                        session.execute(
+                            update(table)
+                            .where(table.metadata_id == old_stat.id)
+                            .values(metadata_id=new_stat.id)
+                        )
+                    session.delete(old_stat)
+                    _LOGGER.debug(
+                        "Merged statistics %s into %s", old_entity_id, new_entity_id
+                    )
+                touched = True
+
+            if touched:
+                migrated += 1
+
+    return migrated
+
+
+def _notify_entity_id_changes(
+    hass: HomeAssistant, id_name: str, renames: list[tuple[str, str]]
+) -> None:
+    """
+    Tell the user which entity ids moved.
+
+    History and statistics follow automatically, but automations, scripts,
+    dashboards and templates cannot be rewritten safely from inside the
+    integration - they live in user-authored YAML and Lovelace storage.
+    Listing the mapping is what turns a silent break into a quick
+    find-and-replace.
+    """
+    lines = "\n".join(f"- `{old}` &rarr; `{new}`" for old, new in renames)
+    persistent_notification.async_create(
+        hass,
+        (
+            f"ThermIQ-MQTT **{id_name}** has replaced its `input_*` helper "
+            f"entities with proper `number`/`select`/`switch` entities.\n\n"
+            f"History and long-term statistics were moved across "
+            f"automatically. Any **automations, scripts, dashboards or "
+            f"templates** still referencing the old ids need updating:\n\n"
+            f"{lines}"
+        ),
+        title="ThermIQ-MQTT: entities renamed",
+        notification_id=f"{DOMAIN}_{id_name}_input_platform_migration",
+    )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/thermiq_mqtt/__init__.py
+++ b/custom_components/thermiq_mqtt/__init__.py
@@ -35,17 +35,15 @@ from .heatpump.thermiq_regs import (
     reg_id,
 )
 
-# from .automation import setup_automations
-from .input_number import setup_input_numbers
-from .input_select import setup_input_selects
-from .input_boolean import setup_input_booleans
-
 _LOGGER = logging.getLogger(__name__)
 SERVICE_SET_VALUE = "set_value"
 
 PLATFORMS = [
     "sensor",
     "binary_sensor",
+    "number",
+    "select",
+    "switch",
 ]
 
 # The dashboard widget ships inside the integration, so installing it is the
@@ -574,28 +572,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     rld = entry.add_update_listener(reload_entry)
     entry.async_on_unload(rld)
 
-    async def finish_setup() -> None:
-        """Create the input_* helper entities, then start MQTT."""
-        await setup_input_numbers(heatpump)
-        await setup_input_selects(heatpump)
-        await setup_input_booleans(heatpump)
-        if hass.is_running:
-            # HA is already up (e.g. the integration was just added via the
-            # UI) - EVENT_HOMEASSISTANT_STARTED has fired and never will
-            # again, so subscribe immediately
-            await heatpump.setup_mqtt()
-        else:
-            # Wait for hass to start before subscribing
-            hass.bus.async_listen_once(
-                EVENT_HOMEASSISTANT_STARTED, handle_hass_started
-            )
-
-    hass.async_create_task(finish_setup())
-
-    # Load the sensor/binary_sensor platforms and await them so the entities
-    # are fully set up before this entry is marked done (avoids races where
-    # consumers access the platform data before it is ready)
+    # Load all platforms (sensor, binary_sensor, number, select, switch) and
+    # await them so the entities are fully set up before this entry is marked
+    # done (avoids races where consumers access the platform data too early)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Subscribe to MQTT
+    if hass.is_running:
+        # HA is already up (e.g. the integration was just added via the UI) -
+        # EVENT_HOMEASSISTANT_STARTED has fired and never will again, so
+        # subscribe immediately
+        await heatpump.setup_mqtt()
+    else:
+        # Wait for hass to start before subscribing
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, handle_hass_started)
 
     return True
 
@@ -652,6 +642,10 @@ class ThermIQWorker:
             {"action": "add", "heatpump": config_entry.data[CONF_ID]},
         )
         return heatpump
+
+    def get_entry(self, config_entry: ConfigEntry):
+        """Get heatpump for a config entry."""
+        return self._heatpumps[config_entry.data[CONF_ID]]
 
     def remove_entry(self, config_entry: ConfigEntry):
         """Remove entry."""

--- a/custom_components/thermiq_mqtt/const.py
+++ b/custom_components/thermiq_mqtt/const.py
@@ -28,11 +28,3 @@ DEFAULT_DBG = False
 AVAILABLE_LANGUAGES = ["en", "se", "fi", "no", "de"]
 
 
-PLATFORM_AUTOMATION = "automation"
-PLATFORM_BINARY_SENSOR = "binary_sensor"
-PLATFORM_GROUP = "group"
-PLATFORM_INPUT_BOOLEAN = "input_boolean"
-PLATFORM_INPUT_NUMBER = "input_number"
-PLATFORM_INPUT_SELECT = "input_select"
-PLATFORM_INPUT_TEXT = "input_text"
-CONF_ENTITY_PLATFORM = "entity_platform"

--- a/custom_components/thermiq_mqtt/const.py
+++ b/custom_components/thermiq_mqtt/const.py
@@ -3,8 +3,8 @@
 # Component domain, used to store component data in hass data.
 DOMAIN = "thermiq_mqtt"
 MANUFACTURER = "ThermIQ.net"
-DEVVERSION ="1.1"
-DATABASE_VERSION = 1.5
+DEVVERSION = "1.1"
+DATABASE_VERSION = 1.6
 
 
 # Database version, used to migrate old versions of data in the recorded history.

--- a/custom_components/thermiq_mqtt/heatpump/__init__.py
+++ b/custom_components/thermiq_mqtt/heatpump/__init__.py
@@ -5,25 +5,6 @@ from collections.abc import Callable
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 
-from homeassistant.components.input_number import (
-    ATTR_VALUE as INP_ATTR_VALUE,
-    DOMAIN as NUMBER_DOMAIN,
-    SERVICE_SET_VALUE as NUMBER_SERVICE_SET_VALUE,
-)
-from homeassistant.components.input_select import (
-    DOMAIN as SELECT_DOMAIN,
-
-)
-from homeassistant.components.input_boolean import (
-    DOMAIN as BOOLEAN_DOMAIN,
-)
-
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    ATTR_OPTION,
-    SERVICE_SELECT_OPTION as SELECT_SERVICE_SET_OPTION,
-)
-
 from homeassistant.components import mqtt
 
 
@@ -65,7 +46,6 @@ class HeatPump:
     @callback
     async def message_received(self, message):
         """Handle new MQTT messages."""
-        from ..input_boolean import (SERVICE_SET_VALUE as BOOLEAN_SERVICE_SET_VALUE,)
         _LOGGER.debug("%s: message.payload:[%s]", self._id, message.payload)
         try:
             json_dict = json.loads(message.payload)
@@ -73,15 +53,10 @@ class HeatPump:
                 for k in json_dict.keys():
                     kstore = k.lower()
                     dstore = k
-                    # # Make INDR_T, EVU and timestamp appear as normal register
-                    # if kstore == "indr_t":
-                    #     kstore = "rf0"
-                    # if kstore == "timestamp":
-                    #     kstore = "rf1"
                     if kstore == "evu":
                         kstore = 'evu'
                         dstore='d300'
-                    # # Create hex notation if incoming register is decimal format
+                    # Create hex notation if incoming register is decimal format
                     # Named registers must be longer than 4 characters to avoid confusion
                     if k[0] == "d" and len(k) < 5:
                         reg = int(k[1:])
@@ -100,87 +75,6 @@ class HeatPump:
 
                     # Internal mapping of ThermIQ_MQTT regs, used to create update events
                     self._hpstate[kstore] = json_dict[k]
-                    # hass.states.async_set(DOMAIN+"." +kstore, json_dict[k])
-
-                    # Map incomming registers to named settings based on id_reg (thermiq_regs)
-                    if kstore in self._id_reg:
-                        # r01 and r03 should be combined with respective decimal part r02 and r04
-                        # i.e thermiq_mqtt_vp1.outdoor_t
-                        if kstore != "r01" and kstore != "r03":
-                            # self._hass.states.async_set(
-                            #     self._domain
-                            #     + "_"
-                            #     + self._id
-                            #     + "."
-                            #     + self._id_reg[kstore],
-                            #     json_dict[k],
-                            # )
-                            ## Set the corresponding input_number/input_select if applicable, incomming message always rules over UI settings
-                            if reg_id[self._id_reg[kstore]][1] in [
-                                "temperature_input",
-                                "time_input",
-                                "sensor_input",
-                                "generated_input",
-                            ]:
-                                context = {
-                                    INP_ATTR_VALUE: json_dict[k],
-                                    ATTR_ENTITY_ID: "input_number."
-                                    + self._domain
-                                    + "_"
-                                    + self._id
-                                    + "_"
-                                    + self._id_reg[kstore],
-                                }
-                                self._hass.async_create_task(
-                                    self._hass.services.async_call(
-                                        NUMBER_DOMAIN,
-                                        NUMBER_SERVICE_SET_VALUE,
-                                        context,
-                                        blocking=False,
-                                    )
-                                )
-                            if reg_id[self._id_reg[kstore]][1] in [
-                                "generated_input_boolean",
-                            ]:
-                                context = {
-                                    INP_ATTR_VALUE: json_dict[k],
-                                    ATTR_ENTITY_ID: "input_boolean."
-                                    + self._domain
-                                    + "_"
-                                    + self._id
-                                    + "_"
-                                    + self._id_reg[kstore],
-                                }
-                                self._hass.async_create_task(
-                                    self._hass.services.async_call(
-                                        BOOLEAN_DOMAIN,
-                                        BOOLEAN_SERVICE_SET_VALUE,
-                                        context,
-                                        blocking=False,
-                                    )
-                                )
-
-                            if reg_id[self._id_reg[kstore]][1] == "select_input":
-                                mode = f"mode{json_dict[k]}"
-
-                                context = {
-                                    ATTR_OPTION: f"{json_dict[k]} - "
-                                    + id_names[mode][self._langid],
-                                    ATTR_ENTITY_ID: "input_select."
-                                    + self._domain
-                                    + "_"
-                                    + self._id
-                                    + "_"
-                                    + self._id_reg[kstore],
-                                }
-                                self._hass.async_create_task(
-                                    self._hass.services.async_call(
-                                        SELECT_DOMAIN,
-                                        SELECT_SERVICE_SET_OPTION,
-                                        context,
-                                        blocking=False,
-                                    )
-                                )
 
                 # Do some post processing of data received
                 self._hpstate["r01"] = self._hpstate["r01"] + self._hpstate["r02"] / 10

--- a/custom_components/thermiq_mqtt/heatpump/__init__.py
+++ b/custom_components/thermiq_mqtt/heatpump/__init__.py
@@ -4,25 +4,6 @@ from collections.abc import Callable
 
 from homeassistant.config_entries import ConfigEntry
 
-from homeassistant.components.input_number import (
-    ATTR_VALUE as INP_ATTR_VALUE,
-    DOMAIN as NUMBER_DOMAIN,
-    SERVICE_SET_VALUE as NUMBER_SERVICE_SET_VALUE,
-)
-from homeassistant.components.input_select import (
-    DOMAIN as SELECT_DOMAIN,
-
-)
-from homeassistant.components.input_boolean import (
-    DOMAIN as BOOLEAN_DOMAIN,
-)
-
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    ATTR_OPTION,
-    SERVICE_SELECT_OPTION as SELECT_SERVICE_SET_OPTION,
-)
-
 from homeassistant.components import mqtt
 
 
@@ -63,7 +44,6 @@ class HeatPump:
     # ###
     async def message_received(self, message):
         """Handle new MQTT messages."""
-        from ..input_boolean import (SERVICE_SET_VALUE as BOOLEAN_SERVICE_SET_VALUE,)
         _LOGGER.debug("%s: message.payload:[%s]", self._id, message.payload)
         try:
             json_dict = json.loads(message.payload)
@@ -103,88 +83,13 @@ class HeatPump:
                     "[%s] [%s] [%s] [%s]", self._id, kstore, json_dict[k], dstore
                 )
 
-                # Internal mapping of ThermIQ_MQTT regs, used to create update events
+                # Store the value under its canonical register key. The
+                # number/select/switch/sensor/binary_sensor entities read from
+                # this shared state when the msg_rec_event fires below, so the
+                # incoming heatpump values always win over the UI.
                 self._hpstate[kstore] = json_dict[k]
                 received.add(kstore)
 
-                # Map incomming registers to named settings based on id_reg (thermiq_regs)
-                if kstore in self._id_reg:
-                    # r01 and r03 should be combined with respective decimal part r02 and r04
-                    # i.e thermiq_mqtt_vp1.outdoor_t
-                    if kstore != "r01" and kstore != "r03":
-                        ## Set the corresponding input_number/input_select if applicable, incomming message always rules over UI settings
-                        regtype = reg_id[self._id_reg[kstore]][1]
-                        if regtype in [
-                            "temperature_input",
-                            "time_input",
-                            "sensor_input",
-                            "generated_input",
-                        ]:
-                            context = {
-                                INP_ATTR_VALUE: json_dict[k],
-                                ATTR_ENTITY_ID: "input_number."
-                                + self._domain
-                                + "_"
-                                + self._id
-                                + "_"
-                                + self._id_reg[kstore],
-                            }
-                            self._hass.async_create_task(
-                                self._hass.services.async_call(
-                                    NUMBER_DOMAIN,
-                                    NUMBER_SERVICE_SET_VALUE,
-                                    context,
-                                    blocking=False,
-                                )
-                            )
-                        if regtype in [
-                            "generated_input_boolean",
-                        ]:
-                            context = {
-                                INP_ATTR_VALUE: json_dict[k],
-                                ATTR_ENTITY_ID: "input_boolean."
-                                + self._domain
-                                + "_"
-                                + self._id
-                                + "_"
-                                + self._id_reg[kstore],
-                            }
-                            self._hass.async_create_task(
-                                self._hass.services.async_call(
-                                    BOOLEAN_DOMAIN,
-                                    BOOLEAN_SERVICE_SET_VALUE,
-                                    context,
-                                    blocking=False,
-                                )
-                            )
-
-                        if regtype == "select_input":
-                            mode = f"mode{json_dict[k]}"
-                            if mode not in id_names:
-                                _LOGGER.warning(
-                                    "Unknown mode value [%s] received for %s, ignoring",
-                                    json_dict[k],
-                                    self._id_reg[kstore],
-                                )
-                            else:
-                                context = {
-                                    ATTR_OPTION: f"{json_dict[k]} - "
-                                    + id_names[mode][self._langid],
-                                    ATTR_ENTITY_ID: "input_select."
-                                    + self._domain
-                                    + "_"
-                                    + self._id
-                                    + "_"
-                                    + self._id_reg[kstore],
-                                }
-                                self._hass.async_create_task(
-                                    self._hass.services.async_call(
-                                        SELECT_DOMAIN,
-                                        SELECT_SERVICE_SET_OPTION,
-                                        context,
-                                        blocking=False,
-                                    )
-                                )
             except (ValueError, KeyError, IndexError, TypeError) as err:
                 _LOGGER.warning(
                     "Could not process key [%s] in MQTT message: %s", k, err

--- a/custom_components/thermiq_mqtt/number.py
+++ b/custom_components/thermiq_mqtt/number.py
@@ -1,0 +1,142 @@
+"""Number entities for ThermIQ heat pump settings."""
+import logging
+from contextlib import suppress
+
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.const import UnitOfTemperature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .heatpump.thermiq_regs import (
+    FIELD_REGNUM,
+    FIELD_REGTYPE,
+    FIELD_UNIT,
+    FIELD_MINVALUE,
+    FIELD_MAXVALUE,
+    id_names,
+    reg_id,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+INPUT_REG_TYPES = [
+    "temperature_input",
+    "time_input",
+    "sensor_input",
+    "generated_input",
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up ThermIQ number entities from a config entry."""
+    worker = hass.data[DOMAIN]
+    heatpump = worker.get_entry(config_entry)
+
+    entities = []
+    for key, reg_def in reg_id.items():
+        if reg_def[FIELD_REGTYPE] in INPUT_REG_TYPES:
+            entities.append(HeatPumpNumber(heatpump, key))
+
+    async_add_entities(entities)
+
+
+class HeatPumpNumber(NumberEntity):
+    """A number entity for a ThermIQ heat pump register."""
+
+    _attr_should_poll = False
+    _attr_mode = NumberMode.BOX
+
+    def __init__(self, heatpump, register_name: str) -> None:
+        """Initialize the number entity."""
+        self._heatpump = heatpump
+        self._register_name = register_name
+        self._reg_def = reg_id[register_name]
+        self._reg = self._reg_def[FIELD_REGNUM]
+
+        # Entity identification
+        self._attr_unique_id = (
+            f"{heatpump._domain}_{heatpump._id}_{register_name}"
+        )
+        self.entity_id = (
+            f"number.{heatpump._domain}_{heatpump._id}_{register_name}"
+        )
+
+        # Friendly name from translations
+        if register_name in id_names:
+            self._attr_name = id_names[register_name][heatpump._langid]
+        else:
+            self._attr_name = register_name
+
+        # Min/max/step
+        self._attr_native_min_value = float(self._reg_def[FIELD_MINVALUE])
+        self._attr_native_max_value = float(self._reg_def[FIELD_MAXVALUE])
+        self._attr_native_step = (
+            0.1 if self._reg == "indr_t" else 1.0
+        )
+
+        # Unit and icon
+        if (
+            self._reg_def[FIELD_REGTYPE] == "temperature_input"
+            or self._reg_def[FIELD_UNIT] in ("C", "°C")
+        ):
+            self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+            self._attr_icon = "mdi:temperature-celsius"
+        else:
+            unit = self._reg_def[FIELD_UNIT]
+            self._attr_native_unit_of_measurement = unit if unit else None
+            self._attr_icon = "mdi:gauge"
+
+        # Device info to group under the heat pump device
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, heatpump._id)},
+        }
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current value from heat pump state."""
+        val = self._heatpump._hpstate.get(self._reg)
+        if val is None or val == -1:
+            return None
+        return float(val)
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the value, and send MQTT command to heat pump."""
+        # Only send if we've received at least one MQTT message
+        if self._heatpump._hpstate.get("mqtt_counter", -1) < 0:
+            return
+
+        current = self._heatpump._hpstate.get(self._reg)
+        if current != value:
+            self._heatpump._hpstate[self._reg] = value
+            self._heatpump._hass.bus.fire(
+                f"{self._heatpump._domain}_{self._heatpump._id}_msg_rec_event",
+                {},
+            )
+            await self._heatpump.send_mqtt_reg(
+                self._register_name, value, 0xFFFF
+            )
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Register event listener when added to hass."""
+        self.async_on_remove(
+            self.hass.bus.async_listen(
+                f"{self._heatpump._domain}_{self._heatpump._id}_msg_rec_event",
+                self._async_update_event,
+            )
+        )
+        # Restore last known value if heat pump hasn't sent data yet
+        if self.native_value is None:
+            if state := await self.async_get_last_state():
+                with suppress(ValueError):
+                    self._heatpump._hpstate[self._reg] = float(state.state)
+
+    async def _async_update_event(self, event) -> None:
+        """Handle heat pump state update event."""
+        self.async_write_ha_state()

--- a/custom_components/thermiq_mqtt/select.py
+++ b/custom_components/thermiq_mqtt/select.py
@@ -1,0 +1,126 @@
+"""Select entities for ThermIQ heat pump mode settings."""
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .heatpump.thermiq_regs import (
+    FIELD_REGNUM,
+    FIELD_REGTYPE,
+    id_names,
+    reg_id,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up ThermIQ select entities from a config entry."""
+    worker = hass.data[DOMAIN]
+    heatpump = worker.get_entry(config_entry)
+
+    entities = []
+    for key, reg_def in reg_id.items():
+        if reg_def[FIELD_REGTYPE] == "select_input":
+            entities.append(HeatPumpSelect(heatpump, key))
+
+    async_add_entities(entities)
+
+
+class HeatPumpSelect(SelectEntity):
+    """A select entity for a ThermIQ heat pump mode register."""
+
+    _attr_should_poll = False
+
+    def __init__(self, heatpump, register_name: str) -> None:
+        """Initialize the select entity."""
+        self._heatpump = heatpump
+        self._register_name = register_name
+        self._reg_def = reg_id[register_name]
+        self._reg = self._reg_def[FIELD_REGNUM]
+
+        # Entity identification
+        self._attr_unique_id = (
+            f"{heatpump._domain}_{heatpump._id}_{register_name}"
+        )
+        self.entity_id = (
+            f"select.{heatpump._domain}_{heatpump._id}_{register_name}"
+        )
+
+        # Friendly name
+        if register_name in id_names:
+            self._attr_name = id_names[register_name][heatpump._langid]
+        else:
+            self._attr_name = register_name
+
+        # Build options list from mode translations
+        self._attr_options = [
+            f"{i} - {id_names[f'mode{i}'][heatpump._langid]}"
+            for i in range(5)
+        ]
+
+        self._attr_icon = None
+
+        # Device info
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, heatpump._id)},
+        }
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current selected option."""
+        val = self._heatpump._hpstate.get(self._reg)
+        if val is None or val == -1:
+            return None
+        try:
+            mode_idx = int(val)
+            if 0 <= mode_idx < len(self._attr_options):
+                return self._attr_options[mode_idx]
+        except (ValueError, TypeError):
+            pass
+        return None
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option and send MQTT command."""
+        # Only send if we've received at least one MQTT message
+        if self._heatpump._hpstate.get("mqtt_counter", -1) <= 0:
+            return
+
+        # Parse the mode number from the option string (e.g. "0 - Off" -> 0)
+        try:
+            value = int(option.split(" - ")[0])
+        except (ValueError, IndexError):
+            _LOGGER.error("Could not parse mode value from option: %s", option)
+            return
+
+        current = self._heatpump._hpstate.get(self._reg)
+        if current != value:
+            self._heatpump._hpstate[self._reg] = value
+            self._heatpump._hass.bus.fire(
+                f"{self._heatpump._domain}_{self._heatpump._id}_msg_rec_event",
+                {},
+            )
+            await self._heatpump.send_mqtt_reg(
+                self._register_name, value, 0xFFFF
+            )
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Register event listener when added to hass."""
+        self.async_on_remove(
+            self.hass.bus.async_listen(
+                f"{self._heatpump._domain}_{self._heatpump._id}_msg_rec_event",
+                self._async_update_event,
+            )
+        )
+
+    async def _async_update_event(self, event) -> None:
+        """Handle heat pump state update event."""
+        self.async_write_ha_state()

--- a/custom_components/thermiq_mqtt/switch.py
+++ b/custom_components/thermiq_mqtt/switch.py
@@ -1,0 +1,120 @@
+"""Switch entities for ThermIQ heat pump boolean settings."""
+import logging
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .heatpump.thermiq_regs import (
+    FIELD_REGNUM,
+    FIELD_REGTYPE,
+    FIELD_BITMASK,
+    id_names,
+    reg_id,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up ThermIQ switch entities from a config entry."""
+    worker = hass.data[DOMAIN]
+    heatpump = worker.get_entry(config_entry)
+
+    entities = []
+    for key, reg_def in reg_id.items():
+        if reg_def[FIELD_REGTYPE] == "generated_input_boolean":
+            entities.append(HeatPumpSwitch(heatpump, key))
+
+    async_add_entities(entities)
+
+
+class HeatPumpSwitch(SwitchEntity):
+    """A switch entity for a ThermIQ heat pump boolean register."""
+
+    _attr_should_poll = False
+
+    def __init__(self, heatpump, register_name: str) -> None:
+        """Initialize the switch entity."""
+        self._heatpump = heatpump
+        self._register_name = register_name
+        self._reg_def = reg_id[register_name]
+        self._reg = self._reg_def[FIELD_REGNUM]
+        self._bitmask = self._reg_def[FIELD_BITMASK]
+
+        # Entity identification
+        self._attr_unique_id = (
+            f"{heatpump._domain}_{heatpump._id}_{register_name}"
+        )
+        self.entity_id = (
+            f"switch.{heatpump._domain}_{heatpump._id}_{register_name}"
+        )
+
+        # Friendly name
+        if register_name in id_names:
+            self._attr_name = id_names[register_name][heatpump._langid]
+        else:
+            self._attr_name = register_name
+
+        self._attr_icon = "mdi:gauge"
+
+        # Device info
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, heatpump._id)},
+        }
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the switch is on."""
+        val = self._heatpump._hpstate.get(self._reg)
+        if val is None or val == -1:
+            return None
+        return bool(int(val) & self._bitmask)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        await self._async_set_value(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        await self._async_set_value(False)
+
+    async def _async_set_value(self, value: bool) -> None:
+        """Set the value and send MQTT command."""
+        reg_value = 1 if value else 0
+
+        # Only send if we've received at least one MQTT message
+        if self._heatpump._hpstate.get("mqtt_counter", -1) <= 0:
+            return
+
+        current = self._heatpump._hpstate.get(self._reg)
+        if current != reg_value:
+            self._heatpump._hpstate[self._reg] = reg_value
+            self._heatpump._hass.bus.fire(
+                f"{self._heatpump._domain}_{self._heatpump._id}_msg_rec_event",
+                {},
+            )
+            await self._heatpump.send_mqtt_reg(
+                self._register_name, reg_value, 0xFFFF
+            )
+        self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Register event listener when added to hass."""
+        self.async_on_remove(
+            self.hass.bus.async_listen(
+                f"{self._heatpump._domain}_{self._heatpump._id}_msg_rec_event",
+                self._async_update_event,
+            )
+        )
+
+    async def _async_update_event(self, event) -> None:
+        """Handle heat pump state update event."""
+        self.async_write_ha_state()


### PR DESCRIPTION
## Summary

Replaces the fragile pattern of injecting entities into HA's built-in `input_number`/`input_select`/`input_boolean` platforms with proper HA entity platforms:

- `input_number.py` → `number.py` (`NumberEntity`)
- `input_select.py` → `select.py` (`SelectEntity`)
- `input_boolean.py` → `switch.py` (`SwitchEntity`)

This addresses multiple reported issues:
- **Fixes #70** — missing helper entities after restart
- **Fixes #71** — "does not generate unique IDs" errors flooding logs on HA upgrade/reload
- Related analysis in #74 (items 6, 7, 8)

## What changed

| Area | Before | After |
|---|---|---|
| Entity platform | Hijacks `hass.data[CONF_ENTITY_PLATFORM]` | Standard `async_setup_entry` per platform |
| Entity lifecycle | Not tracked by config entry | Properly owned, added/removed on reload |
| Event listeners | Never unsubscribed (memory leak) | `async_on_remove()` cleanup |
| State updates | Service calls from `message_received()` | Entities read `_hpstate` directly |
| Platform setup | `async_create_task` (fire-and-forget) | `await async_forward_entry_setups()` |

## Breaking change

Entity domains change:
- `input_number.thermiq_mqtt_*` → `number.thermiq_mqtt_*`
- `input_select.thermiq_mqtt_*` → `select.thermiq_mqtt_*`
- `input_boolean.thermiq_mqtt_*` → `switch.thermiq_mqtt_*`

Users will need to update automations and dashboard card references. The old `input_*.py` files are left in place (but no longer imported) for reference during the transition.

## Test plan

- [ ] Verify number entities appear under the ThermIQ device after install
- [ ] Verify select entity (main_mode) shows mode options and updates from MQTT
- [ ] Verify switch entity (evu_block) toggles and sends MQTT command
- [ ] Verify all entities update when MQTT message arrives
- [ ] Verify no "does not generate unique IDs" errors on integration reload
- [ ] Verify entities are removed when config entry is unloaded
- [ ] Verify value changes from HA UI are sent via MQTT to heat pump

🤖 Generated with [Claude Code](https://claude.com/claude-code)