### PR TITLE
Code cleanup: deprecated APIs, bare excepts, listener leaks, translations

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: "ubuntu-latest"
     name: Validate
     steps:
-        - uses: "actions/checkout@v2"
+        - uses: "actions/checkout@v4"
 
         - name: HACS validation
           uses: "hacs/action@main"

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: "ubuntu-latest"
     name: Validate
     steps:
-        - uses: "actions/checkout@v2"
+        - uses: "actions/checkout@v4"
         - name: HACS validation
           uses: "hacs/action@main"
           with:
@@ -25,11 +25,9 @@ jobs:
     runs-on: "ubuntu-latest"
     name: Check style formatting
     steps:
-        - uses: "actions/checkout@v2"
-        - uses: "actions/setup-python@v1"
+        - uses: "actions/checkout@v4"
+        - uses: "actions/setup-python@v5"
           with:
             python-version: "3.x"
         - run: python3 -m pip install black
-        - run: black .
-
-  
+        - run: black --check .

--- a/custom_components/thermiq_mqtt/__init__.py
+++ b/custom_components/thermiq_mqtt/__init__.py
@@ -1,8 +1,7 @@
 """Component for ThermIQ-MQTT support."""
 import logging
-from builtins import property
 from datetime import datetime
-from sqlalchemy import update, select, delete
+from sqlalchemy import update, select
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, Event

--- a/custom_components/thermiq_mqtt/binary_sensor.py
+++ b/custom_components/thermiq_mqtt/binary_sensor.py
@@ -1,29 +1,14 @@
 import logging
-from numbers import Number
-from typing import TYPE_CHECKING, Literal, final
-from homeassistant.core import HomeAssistant, callback
 
-from homeassistant.const import STATE_OFF, STATE_ON
-
-from homeassistant.components.binary_sensor import (
-    BinarySensorDeviceClass,
-    BinarySensorEntity,
-    BinarySensorEntityDescription,
-)
+from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.const import (
     ATTR_IDENTIFIERS,
     ATTR_MANUFACTURER,
     ATTR_MODEL,
     ATTR_NAME,
-    STATE_OFF,
-    STATE_ON,
-    EntityCategory)
-
+)
 from homeassistant.helpers.device_registry import DeviceEntryType
 
-from homeassistant.const import (
-    PERCENTAGE
-)
 from .const import (
     DOMAIN,
     MANUFACTURER,
@@ -31,21 +16,13 @@ from .const import (
     CONF_ID,
 )
 
-
 from .heatpump.thermiq_regs import (
     FIELD_BITMASK,
-    FIELD_MAXVALUE,
-    FIELD_MINVALUE,
     FIELD_REGNUM,
     FIELD_REGTYPE,
-    FIELD_UNIT,
     id_names,
     reg_id,
 )
-
-
-from functools import cached_property
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,32 +31,22 @@ async def async_setup_entry(
     hass, config_entry, async_add_entities, discovery_info=None
 ):
     """Set up platform for a new integration.
+
     Called by the HA framework after async_setup_platforms has been called
     during initialization of a new integration.
     """
 
-    @callback
-    def async_add_sensor(sensor):
-        """Add a ThermIQ sensor property"""
-        async_add_entities([sensor], True)
-        # _LOGGER.debug('Added new sensor %s / %s', sensor.entity_id, sensor.unique_id)
-
-    worker = hass.data[DOMAIN].worker
     heatpump = hass.data[DOMAIN]._heatpumps[config_entry.data[CONF_ID]]
     entities = []
 
     for key in reg_id:
-        if reg_id[key][1] in [
-            "binary_sensor",
-            "generated_input_boolean"
-        ]:
+        if reg_id[key][FIELD_REGTYPE] in ("binary_sensor", "generated_input_boolean"):
             device_id = key
             if key in id_names:
                 friendly_name = id_names[key][heatpump._langid]
             else:
                 friendly_name = key
             vp_reg = reg_id[key][FIELD_REGNUM]
-            vp_type = reg_id[key][FIELD_REGTYPE]
             bitmask = reg_id[key][FIELD_BITMASK]
 
             entities.append(
@@ -96,122 +63,47 @@ async def async_setup_entry(
 
 
 class HeatPumpBinarySensor(BinarySensorEntity):
-    """Common functionality for all entities."""
+    """Binary sensor entity for a ThermIQ heat pump register."""
+
+    _attr_should_poll = False
 
     def __init__(self, hass, heatpump, device_id, vp_reg, friendly_name, bitmask):
-        self.hass = hass
         self._heatpump = heatpump
         self._hpstate = heatpump._hpstate
-
-        # set HA instance attributes directly (mostly don't use property)
-        # self._attr_unique_id
         self.entity_id = f"binary_sensor.{heatpump._domain}_{heatpump._id}_{device_id}"
         self._attr_unique_id = "uid-" + self.entity_id
-
-        _LOGGER.debug("entity_id:" + self.entity_id)
-        _LOGGER.debug("idx:" + device_id)
-        self._name = friendly_name
-        self._state = None
-        self._attr_is_on=False
-        self._icon = "mdi:flash-outline"
-
-        self._entity_picture = None
-        self._available = True
+        self._attr_name = friendly_name
+        self._attr_icon = "mdi:flash-outline"
 
         self._idx = device_id
         self._vp_reg = vp_reg
         self._bitmask = bitmask
-        # ???
-        if isinstance(vp_reg,Number):
-            self._sorter = int("0x" + vp_reg[1:], 0) * 65536 + int(bitmask)
-        else:
-            self._sorter = 256 * 65536 + int(bitmask)
 
-        # Listen for the ThermIQ rec event indicating new data
-        hass.bus.async_listen(
-            heatpump._domain + "_" + heatpump._id + "_msg_rec_event",
-            self._async_update_event,
-        )
-
-        # This is needed
         self._attr_device_info = {
-            ATTR_IDENTIFIERS: {(DOMAIN,heatpump._id)},
+            ATTR_IDENTIFIERS: {(DOMAIN, heatpump._id)},
             ATTR_NAME: "Heatpump status",
             ATTR_MANUFACTURER: MANUFACTURER,
             ATTR_MODEL: DEVVERSION,
             "entry_type": DeviceEntryType.SERVICE,
         }
 
-
     @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self._name
+    def is_on(self) -> bool | None:
+        """Return true if the binary sensor is on."""
+        reg_state = self._hpstate.get(self._vp_reg)
+        if reg_state is None or reg_state == -1:
+            return None
+        return (int(reg_state) & self._bitmask) > 0
 
-    @property
-    def should_poll(self):
-        """No need to poll. Coordinator notifies entity of updates."""
-        return False
-
-    @final
-    @property
-    def state(self) -> Literal["on", "off"]:
-        """Return the state of the sensor."""
-        return STATE_ON if (self._state) else STATE_OFF
-
-    @property
-    def vp_reg(self):
-        """Return the device class of the sensor."""
-        return self._vp_reg
-
-    @cached_property
-    def is_on(self) -> bool:
-        return (self._state==True)
-
-    @property
-    def sorter(self):
-        """Return the state of the sensor."""
-        return self._sorter
-
-    @property
-    def icon(self):
-        """Return the icon of the sensor."""
-        return self._icon
-
-    async def async_update(self):
-        """Update the value of the entity."""
-        """Update the new state of the sensor."""
-
-        _LOGGER.debug("update: " + self._idx)
-        reg_state = self._hpstate[self._vp_reg]
-        if self._state is None:
-            _LOGGER.warning("Could not get data for %s", self._idx)
-        else:
-            self._state = (int(reg_state) & self._bitmask) > 0
-            self._attr_is_on = self._state
+    async def async_added_to_hass(self) -> None:
+        """Register event listener when added to hass."""
+        self.async_on_remove(
+            self.hass.bus.async_listen(
+                f"{self._heatpump._domain}_{self._heatpump._id}_msg_rec_event",
+                self._async_update_event,
+            )
+        )
 
     async def _async_update_event(self, event):
-        """Update the new state of the sensor."""
-
-        _LOGGER.debug("event: " + self._idx)
-        if self._vp_reg=='evu':
-            _LOGGER.debug("EVU reg state read special")
-        reg_state = self._hpstate[self._vp_reg]
-        if reg_state is None:
-            _LOGGER.debug("Could not get data for %s", self._idx)
-            self._state = None
-            bool_state = None
-            self._attr_is_on = False
-        else:
-            bool_state = (int(reg_state) & self._bitmask) > 0
-
-        if self._state != bool_state:
-            self._state = bool_state
-            self._attr_is_on = self._state
-            self.async_schedule_update_ha_state()
-            _LOGGER.debug("async_update_ha: %s: [%s]",self._idx, str(bool_state))
-
-    @property
-    def device_class(self):
-        """Return the class of this device."""
-        return f"{DOMAIN}_HeatPumpSensor"
+        """Update the state of the binary sensor."""
+        self.async_write_ha_state()

--- a/custom_components/thermiq_mqtt/config_flow.py
+++ b/custom_components/thermiq_mqtt/config_flow.py
@@ -102,7 +102,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 unique_id = f"{DOMAIN}_{id_name}"
                 await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_configured()
-            except:
+            except Exception:
                 return self.async_show_form(
                     step_id="user",
                     data_schema=error_schema,
@@ -116,7 +116,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 elif prefix.endswith("/"):
                     prefix = prefix[:-1]
                 valid_subscribe_topic(f"{prefix}/#")
-            except:
+            except Exception:
                 return self.async_show_form(
                     step_id="user",
                     data_schema=error_schema,
@@ -126,7 +126,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 lang = AVAILABLE_LANGUAGES.index(user_input[CONF_LANGUAGE])
 
-            except:
+            except Exception:
                 return self.async_show_form(
                     step_id="user",
                     data_schema=error_schema,
@@ -146,7 +146,7 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     },
                     options={},
                 )
-            except:
+            except Exception:
                 return self.async_show_form(
                     step_id="user",
                     data_schema=error_schema,
@@ -177,8 +177,6 @@ class OptionsFlow(config_entries.OptionsFlow):
         return data
 
     async def async_step_user(self, user_input=None):
-        s = self.config_entry.data.get(CONF_LANGUAGE)
-
         DATA_SCHEMA = vol.Schema(
             {
                 vol.Required(
@@ -236,7 +234,7 @@ class OptionsFlow(config_entries.OptionsFlow):
             try:
                 entryTitle = self.config_entry.title
                 id_name = self.config_entry.data[CONF_ID]
-            except:
+            except Exception:
                 return self.async_show_form(
                     step_id="user",
                     data_schema=error_schema,
@@ -251,7 +249,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                     prefix = prefix[:-1]
                 valid_subscribe_topic(f"{prefix}/#")
 
-            except:
+            except Exception:
                 return self.async_show_form(
                     step_id="user",
                     data_schema=error_schema,
@@ -261,7 +259,7 @@ class OptionsFlow(config_entries.OptionsFlow):
             try:
                 lang = AVAILABLE_LANGUAGES.index(user_input[CONF_LANGUAGE])
 
-            except:
+            except Exception:
                 return self.async_show_form(
                     step_id="user",
                     data_schema=error_schema,
@@ -287,7 +285,7 @@ class OptionsFlow(config_entries.OptionsFlow):
                 # This is the options entry, jeep it empty
                 return self.async_create_entry(title="", data={})
 
-            except:
+            except Exception:
                 return self.async_show_form(
                     step_id="user",
                     data_schema=error_schema,

--- a/custom_components/thermiq_mqtt/heatpump/__init__.py
+++ b/custom_components/thermiq_mqtt/heatpump/__init__.py
@@ -315,7 +315,7 @@ class HeatPump:
     def get_value(self, item):
         """Get value for sensor."""
         res = self._hpstate.get(item)
-        _LOGGER.debug("get_value(" + item + ")=%d", res)
+        _LOGGER.debug("get_value(" + item + ")=%s", res)
         return res
 
     def update_state(self, command, state_command):

--- a/custom_components/thermiq_mqtt/sensor.py
+++ b/custom_components/thermiq_mqtt/sensor.py
@@ -1,27 +1,20 @@
 import logging
-from homeassistant.core import HomeAssistant, callback
 
-
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.const import (
     ATTR_IDENTIFIERS,
     ATTR_MANUFACTURER,
     ATTR_MODEL,
     ATTR_NAME,
+    UnitOfTemperature,
+    UnitOfElectricCurrent,
+    UnitOfTime,
 )
 from homeassistant.helpers.device_registry import DeviceEntryType
-from datetime import datetime
-from homeassistant.helpers.entity import Entity, async_generate_entity_id
-
-from homeassistant.const import (
-    UnitOfTemperature,
-    PERCENTAGE,
-    UnitOfElectricCurrent,
-    UnitOfTime
-)
-
-from homeassistant.components.sensor import SensorDeviceClass
-
 
 from .const import (
     DOMAIN,
@@ -31,9 +24,6 @@ from .const import (
 )
 
 from .heatpump.thermiq_regs import (
-    FIELD_BITMASK,
-    FIELD_MAXVALUE,
-    FIELD_MINVALUE,
     FIELD_REGNUM,
     FIELD_REGTYPE,
     FIELD_UNIT,
@@ -53,18 +43,11 @@ async def async_setup_entry(
     during initialization of a new integration.
     """
 
-    @callback
-    def async_add_sensor(sensor):
-        """Add a ThermIQ sensor property"""
-        async_add_entities([sensor], True)
-        # _LOGGER.debug('Added new sensor %s / %s', sensor.entity_id, sensor.unique_id)
-
-    worker = hass.data[DOMAIN].worker
     heatpump = hass.data[DOMAIN]._heatpumps[config_entry.data[CONF_ID]]
     entities = []
 
     for key in reg_id:
-        if reg_id[key][1] in [
+        if reg_id[key][FIELD_REGTYPE] in [
             "temperature",
             "temperature_input",
             "time_input",
@@ -82,9 +65,9 @@ async def async_setup_entry(
                 friendly_name = id_names[key][heatpump._langid]
             else:
                 friendly_name = key
-            vp_reg = reg_id[key][0]
-            vp_type = reg_id[key][1]
-            vp_unit = reg_id[key][2]
+            vp_reg = reg_id[key][FIELD_REGNUM]
+            vp_type = reg_id[key][FIELD_REGTYPE]
+            vp_unit = reg_id[key][FIELD_UNIT]
 
             entities.append(
                 HeatPumpSensor(
@@ -101,155 +84,74 @@ async def async_setup_entry(
 
 
 class HeatPumpSensor(SensorEntity):
-    """Common functionality for all entities."""
+    """Sensor entity for a ThermIQ heat pump register."""
+
+    _attr_should_poll = False
 
     def __init__(
         self, hass, heatpump, device_id, vp_reg, friendly_name, vp_type, vp_unit
     ):
-        self.hass = hass
         self._heatpump = heatpump
         self._hpstate = heatpump._hpstate
-        # set HA instance attributes directly (mostly don't use property)
-        # self._attr_unique_id
         self.entity_id = f"sensor.{heatpump._domain}_{heatpump._id}_{device_id}"
         self._attr_unique_id = "uid-" + self.entity_id
-
-        _LOGGER.debug("entity_id:" + self.entity_id)
-        _LOGGER.debug("idx:" + device_id)
-        self._name = friendly_name
-        self._state = None
-        self._icon = None
+        self._attr_name = friendly_name
         self._attr_state_class = SensorStateClass.MEASUREMENT
-
-        # Override for known types
-        if (vp_type in ["temperature_input","temperature"]) or (
-            vp_unit
-            in [
-                "C","°C",
-            ]
-        ):
-            self._icon = "mdi:temperature-celsius"
-            self._unit =UnitOfTemperature.CELSIUS
-            self._attr_state_class = SensorStateClass.MEASUREMENT
-            self._attr_device_class = SensorDeviceClass.TEMPERATURE
-
-        elif (vp_type in ["time",] and (
-            vp_unit
-            in [
-                "h",
-            ]
-            )):
-            self._attr_state_class = SensorStateClass.TOTAL_INCREASING
-            self._attr_device_class = SensorDeviceClass.DURATION
-            self._icon = "mdi:clock-star-four-points-outline"
-            self._unit =UnitOfTime.HOURS
-
-        elif (vp_type in ["sensor",]) and (
-            vp_unit
-            in [
-                "A",
-            ]
-            ):
-            self._attr_state_class = SensorStateClass.MEASUREMENT
-            self._attr_device_class = SensorDeviceClass.CURRENT
-            self._icon = "mdi:clock-star-four-points-outline"
-            self._unit =UnitOfElectricCurrent.AMPERE
-
-
-        elif (vp_unit in ["dBm",]):
-            self._attr_state_class = SensorStateClass.MEASUREMENT
-            self._attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
-            self._icon = "mdi:wifi"
-            self._unit ='dBm'
-
-
-        elif (vp_type in [
-            "sensor_boolean",
-        ]):
-            self._unit = ""
-            self._icon = "mdi:alert"
-        else:
-            self._unit = vp_unit
-            self._icon = "mdi:gauge"
-        # "mdi:thermometer" ,"mdi:oil-temperature", "mdi:gauge", "mdi:speedometer", "mdi:alert"
-        self._entity_picture = None
-        self._available = True
 
         self._idx = device_id
         self._vp_reg = vp_reg
 
-        # self.device_class [temperature, voltage,
-        #self.state_class= measurement
+        # Set device class, unit, and icon based on register type
+        if vp_type in ("temperature_input", "temperature") or vp_unit in ("C", "°C"):
+            self._attr_icon = "mdi:temperature-celsius"
+            self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+            self._attr_device_class = SensorDeviceClass.TEMPERATURE
 
-        # Listen for the ThermIQ rec event indicating new data
-        hass.bus.async_listen(
-            heatpump._domain + "_" + heatpump._id + "_msg_rec_event",
-            self._async_update_event,
-        )
+        elif vp_type == "time" and vp_unit == "h":
+            self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+            self._attr_device_class = SensorDeviceClass.DURATION
+            self._attr_icon = "mdi:clock-star-four-points-outline"
+            self._attr_native_unit_of_measurement = UnitOfTime.HOURS
 
-        # This is needed
+        elif vp_type == "sensor" and vp_unit == "A":
+            self._attr_device_class = SensorDeviceClass.CURRENT
+            self._attr_icon = "mdi:flash"
+            self._attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+
+        elif vp_unit == "dBm":
+            self._attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+            self._attr_icon = "mdi:wifi"
+            self._attr_native_unit_of_measurement = "dBm"
+
+        elif vp_type == "sensor_boolean":
+            self._attr_native_unit_of_measurement = ""
+            self._attr_icon = "mdi:alert"
+        else:
+            self._attr_native_unit_of_measurement = vp_unit
+            self._attr_icon = "mdi:gauge"
+
         self._attr_device_info = {
-            ATTR_IDENTIFIERS: {(DOMAIN,heatpump._id)},
+            ATTR_IDENTIFIERS: {(DOMAIN, heatpump._id)},
             ATTR_NAME: "Heatpump status",
             ATTR_MANUFACTURER: MANUFACTURER,
             ATTR_MODEL: DEVVERSION,
             "entry_type": DeviceEntryType.SERVICE,
         }
 
-
-
     @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self._name
-
-    @property
-    def should_poll(self):
-        """No need to poll. Coordinator notifies entity of updates."""
-        return False
-
-    @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
-        return self._state
+        return self._hpstate.get(self._vp_reg)
 
-    @property
-    def vp_reg(self):
-        """Return the device class of the sensor."""
-        return self._vp_reg
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement."""
-        return self._unit
-
-    @property
-    def icon(self):
-        """Return the icon of the sensor."""
-        return self._icon
-
-    async def async_update(self):
-        """Update the value of the entity."""
-        """Update the new state of the sensor."""
-
-        _LOGGER.debug("update: " + self._idx)
-        self._state = self._hpstate.get_value(self._vp_reg)
-        if self._state is None:
-            _LOGGER.warning("Could not get data for %s", self._idx)
+    async def async_added_to_hass(self) -> None:
+        """Register event listener when added to hass."""
+        self.async_on_remove(
+            self.hass.bus.async_listen(
+                f"{self._heatpump._domain}_{self._heatpump._id}_msg_rec_event",
+                self._async_update_event,
+            )
+        )
 
     async def _async_update_event(self, event):
         """Update the new state of the sensor."""
-
-        _LOGGER.debug("event: " + self._idx)
-        state = self._hpstate[self._vp_reg]
-        if state is None:
-            _LOGGER.debug("Could not get data for %s", self._idx)
-        if self._state != state:
-            self._state = state
-            self.async_schedule_update_ha_state()
-            _LOGGER.debug("async_update_ha: %s", str(state))
-
-    @property
-    def device_class(self):
-        """Return the class of this device."""
-        return f"{DOMAIN}_HeatPumpSensor"
+        self.async_write_ha_state()

--- a/custom_components/thermiq_mqtt/translations/se.json
+++ b/custom_components/thermiq_mqtt/translations/se.json
@@ -1,47 +1,47 @@
 {
   "config": {
-    "flow_title": "Flow title",
+    "flow_title": "Konfiguration",
     "abort": {
-      "already_configured": "The entered id name is already in use."
+      "already_configured": "Det angivna ID-namnet används redan."
     },
     "error": {
-      "invalid_nodename": "The entered MQTT Nodename is not valid",
-      "creation_id": "The Unique ID is not Unique or not valid",
-      "creation_error": "An error occured while updating configuration object",
-      "invalid_language": "An error occured while creating configuration object"
+      "invalid_nodename": "Det angivna MQTT-nodnamnet är inte giltigt",
+      "creation_id": "Det unika ID:t är inte unikt eller inte giltigt",
+      "creation_error": "Ett fel uppstod vid skapandet av konfigurationsobjektet",
+      "invalid_language": "Ett fel uppstod vid val av språk"
     },
     "step": {
       "user": {
         "data": {
-          "id_name": "Unique ID",
-          "mqtt_node": "MQTT Nodename",
-          "language": "Language",
-          "hexformat": "Use hexformat for registers i MQTT",
-          "thermiq_dbg": "Enable debug",
-          "migrate_data": "Request migration of old data in recorder database (may take time)"
+          "id_name": "Unikt ID",
+          "mqtt_node": "MQTT-nodnamn",
+          "language": "Språk",
+          "hexformat": "Använd hexformat för register i MQTT",
+          "thermiq_dbg": "Aktivera MQTT-debug genom att lägga till '_dbg' till nodnamnet",
+          "migrate_data": "Begär migrering av gamla data i recorder-databasen (kan ta tid)"
         },
-        "title": "Heatpump config",
-        "description": "Set up a new ThermIQ_MQTT Instance"
+        "title": "Värmepumpskonfiguration",
+        "description": "Konfigurera en ny ThermIQ_MQTT-instans"
       }
     },
     "progress": {
-      "slow_task": "This message will be displayed if `slow_task` is returned as `progress_action` for `async_show_progress`."
+      "slow_task": "Detta meddelande visas om 'slow_task' returneras som 'progress_action' för 'async_show_progress'."
     }
   },
   "options": {
     "abort": {
-      "already_configured": "The entered id name is already in use."
+      "already_configured": "Det angivna ID-namnet används redan."
     },
     "step": {
       "user": {
         "data": {
-          "mqtt_node": "MQTT Nodename",
-          "language": "Language",
-          "hexformat": "Use hexformat for registers i MQTT",
-          "thermiq_dbg": "Enable debug",
-          "migrate_data": "Request migration of old data in recorder database (may take time)"
+          "mqtt_node": "MQTT-nodnamn",
+          "language": "Språk",
+          "hexformat": "Använd hexformat för register i MQTT",
+          "thermiq_dbg": "Aktivera MQTT-debug genom att lägga till '_dbg' till nodnamnet",
+          "migrate_data": "Begär migrering av gamla data i recorder-databasen (kan ta tid)"
         },
-        "title": "Options"
+        "title": "Inställningar"
       }
     }
   }


### PR DESCRIPTION
## Summary

Low-risk modernization and cleanup addressing items from #74:

- **Deprecated sensor API** → modern `native_value` / `native_unit_of_measurement`
- **Bare `except:` clauses** → `except Exception:` (8 occurrences in config_flow.py)
- **Event listener memory leak** → `async_on_remove()` cleanup in sensor + binary_sensor
- **Invalid `device_class`** → removed custom string, let `_attr_device_class` work (fixes #72)
- **`cached_property` on `is_on`** → `@property` so binary sensor state updates work
- **Swedish translations** → `se.json` actually translated to Swedish
- **GitHub Actions** → updated to current versions, fixed `black --check`
- **Misc** — removed unused imports, duplicate imports, dead variables

## Changes by file

| File | Changes |
|---|---|
| `sensor.py` | `native_value` property, `async_on_remove`, remove duplicate imports, `_attr_*` pattern |
| `binary_sensor.py` | `is_on` reads `_hpstate` directly, `async_on_remove`, remove `cached_property`/unused imports |
| `config_flow.py` | `except:` → `except Exception:` (×8), remove unused variable |
| `__init__.py` | Remove `from builtins import property`, unused `delete` import |
| `heatpump/__init__.py` | Fix `%d` → `%s` in debug log (prevents TypeError on None) |
| `translations/se.json` | Actual Swedish translation |
| `.github/workflows/*.yaml` | checkout v2→v4, setup-python v1→v5, `black --check` |

## Test plan

- [ ] Verify sensor values display correctly (native_value replaces state)
- [ ] Verify temperature sensors show correct units and device class
- [ ] Verify binary sensors update on MQTT messages
- [ ] Verify config flow works (add new heat pump, edit options)
- [ ] Verify integration reload doesn't leak event listeners
- [ ] Verify Swedish translation shows in HA UI when language is set to "se"
- [ ] Verify CI passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)