### PR TITLE
Fix runtime MQTT subscribe, unload leaks, and migration executor bugs

### DIFF
--- a/custom_components/thermiq_mqtt/__init__.py
+++ b/custom_components/thermiq_mqtt/__init__.py
@@ -1,8 +1,7 @@
 """Component for ThermIQ-MQTT support."""
 import logging
-from builtins import property
 from datetime import datetime
-from sqlalchemy import update, select, delete
+from sqlalchemy import update, select
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, Event
@@ -164,56 +163,64 @@ async def async_migrate_state_temperature_celsius(hass: HomeAssistant, config_en
 async def _migrate_celsius(hass: HomeAssistant, recorder, entity_id: str, decimal) -> bool:
     """
     Migrate statistics metadata for a single entity.
+
+    Database work runs in the recorder executor; async_change_statistics_unit
+    is a loop-only API and must be called from the event loop, never from
+    inside the executor job.
     Returns True if successful, False otherwise.
     """
 
-    def _update_celsius(decimal=False):
-        """Update metadata within a database session."""
+    def _update_celsius():
+        """Update metadata within a database session (executor thread).
 
-        try:
-             # Create the session inside the executor job
-            with session_scope(hass=hass, read_only=False) as session:
-                # First check if metadata exists
-                stmt = select(StatisticsMeta).where(
-                    StatisticsMeta.statistic_id == entity_id
+        Returns (found, current_unit). The non-decimal unit fix is done
+        directly in the database here; a needed decimal conversion is
+        signalled back to the event loop via the returned unit.
+        """
+        with session_scope(hass=hass, read_only=False) as session:
+            # First check if metadata exists
+            stmt = select(StatisticsMeta).where(
+                StatisticsMeta.statistic_id == entity_id
+            )
+            result = session.execute(stmt)
+            existing = result.scalar_one_or_none()
+            if existing is None:
+                return (False, None)  # Not an error - sensor might be new
+
+            unit = existing.unit_of_measurement
+            if unit is None:
+                unit = ''
+            if not decimal and unit != UnitOfTemperature.CELSIUS:
+                update_unit = (
+                    update(StatisticsMeta)
+                    .where(StatisticsMeta.statistic_id == entity_id)
+                    .values(
+                        unit_of_measurement=UnitOfTemperature.CELSIUS
+                    )
                 )
-                result = session.execute(stmt)
-                existing = result.scalar_one_or_none()
-                if existing is None:
-                    _LOGGER.debug("No statistics metadata found for %s (new sensor)",entity_id)
-                    return True  # Not an error - sensor might be new
-
-                unit = existing.unit_of_measurement
-                if unit is None:
-                    unit=''
-                if decimal:
-                    if unit!= '0.1'+UnitOfTemperature.CELSIUS:
-                        async_change_statistics_unit(hass,entity_id,new_unit_of_measurement='0.1' + UnitOfTemperature.CELSIUS, old_unit_of_measurement=unit)
-                    else:
-                        _LOGGER.debug("No unit change needed for %s", entity_id)
-                else:
-                    if unit!= UnitOfTemperature.CELSIUS:
-                        update_unit = (
-                            update(StatisticsMeta)
-                            .where(StatisticsMeta.statistic_id == entity_id)
-                            .values(
-                                unit_of_measurement=UnitOfTemperature.CELSIUS
-                            )
-                        )
-                        stats_result = session.execute(update_unit)
-                        _LOGGER.debug("Updated %s rows in Statistics", stats_result.rowcount)
-                        async_change_statistics_unit(hass,entity_id,new_unit_of_measurement=UnitOfTemperature.CELSIUS, old_unit_of_measurement=UnitOfTemperature.CELSIUS)
-                    else:
-                        _LOGGER.debug("No unit change needed for %s", entity_id)
-                return True
-
-        except Exception as e:
-            _LOGGER.error("Error in database operation for %s: %s", entity_id, str(e))
-            return False
+                stats_result = session.execute(update_unit)
+                _LOGGER.debug("Updated %s rows in StatisticsMeta", stats_result.rowcount)
+            return (True, unit)
 
     try:
-        result = recorder.async_add_executor_job(_update_celsius)
-        return result
+        found, unit = await recorder.async_add_executor_job(_update_celsius)
+        if not found:
+            _LOGGER.debug("No statistics metadata found for %s (new sensor)", entity_id)
+            return True
+
+        if decimal:
+            decimal_unit = '0.1' + UnitOfTemperature.CELSIUS
+            if unit != decimal_unit:
+                # Called from the event loop as required
+                async_change_statistics_unit(
+                    hass,
+                    entity_id,
+                    new_unit_of_measurement=decimal_unit,
+                    old_unit_of_measurement=unit,
+                )
+            else:
+                _LOGGER.debug("No unit change needed for %s", entity_id)
+        return True
     except Exception as e:
         _LOGGER.error("Could not update celsius for %s: %s", entity_id, str(e), exc_info=True)
         return False
@@ -505,7 +512,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def handle_hass_started(_event: Event) -> None:
         """Event handler for when HA has started."""
-        await hass.async_create_task(heatpump.setup_mqtt())
+        await heatpump.setup_mqtt()
 
     # One common ThermIQWorker serves all HeatPump objects
     if DOMAIN in hass.data:
@@ -518,17 +525,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Make config reload
     rld = entry.add_update_listener(reload_entry)
     entry.async_on_unload(rld)
-    hass.async_create_task(setup_input_numbers(heatpump))
-    hass.async_create_task(setup_input_selects(heatpump))
-    hass.async_create_task(setup_input_booleans(heatpump))
+
+    async def finish_setup() -> None:
+        """Create the input_* helper entities, then start MQTT."""
+        await setup_input_numbers(heatpump)
+        await setup_input_selects(heatpump)
+        await setup_input_booleans(heatpump)
+        if hass.is_running:
+            # HA is already up (e.g. the integration was just added via the
+            # UI) - EVENT_HOMEASSISTANT_STARTED has fired and never will
+            # again, so subscribe immediately
+            await heatpump.setup_mqtt()
+        else:
+            # Wait for hass to start before subscribing
+            hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_STARTED, handle_hass_started
+            )
+
+    hass.async_create_task(finish_setup())
 
     # Load the platforms for heatpump
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     )
-
-    # Wait for hass to start and then add the input_* entities
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, handle_hass_started)
 
     return True
 
@@ -538,6 +557,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         worker = hass.data[DOMAIN]
+        # Unsubscribe MQTT and remove the generated helper entities so a
+        # reload does not leak subscriptions or orphan input_* entities
+        heatpump = worker.heatpumps.get(entry.data[CONF_ID])
+        if heatpump is not None:
+            await heatpump.async_reset()
         worker.remove_entry(entry)
         if worker.is_idle():
             # also remove worker if not used by any entry any more

--- a/custom_components/thermiq_mqtt/__init__.py
+++ b/custom_components/thermiq_mqtt/__init__.py
@@ -1,9 +1,8 @@
 """Component for ThermIQ-MQTT support."""
 import logging
-from builtins import property
 from datetime import datetime
 from pathlib import Path
-from sqlalchemy import update, select, delete
+from sqlalchemy import update, select
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, Event
@@ -212,56 +211,64 @@ async def async_migrate_state_temperature_celsius(hass: HomeAssistant, config_en
 async def _migrate_celsius(hass: HomeAssistant, recorder, entity_id: str, decimal) -> bool:
     """
     Migrate statistics metadata for a single entity.
+
+    Database work runs in the recorder executor; async_change_statistics_unit
+    is a loop-only API and must be called from the event loop, never from
+    inside the executor job.
     Returns True if successful, False otherwise.
     """
 
-    def _update_celsius(decimal=False):
-        """Update metadata within a database session."""
+    def _update_celsius():
+        """Update metadata within a database session (executor thread).
 
-        try:
-             # Create the session inside the executor job
-            with session_scope(hass=hass, read_only=False) as session:
-                # First check if metadata exists
-                stmt = select(StatisticsMeta).where(
-                    StatisticsMeta.statistic_id == entity_id
+        Returns (found, current_unit). The non-decimal unit fix is done
+        directly in the database here; a needed decimal conversion is
+        signalled back to the event loop via the returned unit.
+        """
+        with session_scope(hass=hass, read_only=False) as session:
+            # First check if metadata exists
+            stmt = select(StatisticsMeta).where(
+                StatisticsMeta.statistic_id == entity_id
+            )
+            result = session.execute(stmt)
+            existing = result.scalar_one_or_none()
+            if existing is None:
+                return (False, None)  # Not an error - sensor might be new
+
+            unit = existing.unit_of_measurement
+            if unit is None:
+                unit = ''
+            if not decimal and unit != UnitOfTemperature.CELSIUS:
+                update_unit = (
+                    update(StatisticsMeta)
+                    .where(StatisticsMeta.statistic_id == entity_id)
+                    .values(
+                        unit_of_measurement=UnitOfTemperature.CELSIUS
+                    )
                 )
-                result = session.execute(stmt)
-                existing = result.scalar_one_or_none()
-                if existing is None:
-                    _LOGGER.debug("No statistics metadata found for %s (new sensor)",entity_id)
-                    return True  # Not an error - sensor might be new
-
-                unit = existing.unit_of_measurement
-                if unit is None:
-                    unit=''
-                if decimal:
-                    if unit!= '0.1'+UnitOfTemperature.CELSIUS:
-                        async_change_statistics_unit(hass,entity_id,new_unit_of_measurement='0.1' + UnitOfTemperature.CELSIUS, old_unit_of_measurement=unit)
-                    else:
-                        _LOGGER.debug("No unit change needed for %s", entity_id)
-                else:
-                    if unit!= UnitOfTemperature.CELSIUS:
-                        update_unit = (
-                            update(StatisticsMeta)
-                            .where(StatisticsMeta.statistic_id == entity_id)
-                            .values(
-                                unit_of_measurement=UnitOfTemperature.CELSIUS
-                            )
-                        )
-                        stats_result = session.execute(update_unit)
-                        _LOGGER.debug("Updated %s rows in Statistics", stats_result.rowcount)
-                        async_change_statistics_unit(hass,entity_id,new_unit_of_measurement=UnitOfTemperature.CELSIUS, old_unit_of_measurement=UnitOfTemperature.CELSIUS)
-                    else:
-                        _LOGGER.debug("No unit change needed for %s", entity_id)
-                return True
-
-        except Exception as e:
-            _LOGGER.error("Error in database operation for %s: %s", entity_id, str(e))
-            return False
+                stats_result = session.execute(update_unit)
+                _LOGGER.debug("Updated %s rows in StatisticsMeta", stats_result.rowcount)
+            return (True, unit)
 
     try:
-        result = await recorder.async_add_executor_job(_update_celsius)
-        return result
+        found, unit = await recorder.async_add_executor_job(_update_celsius)
+        if not found:
+            _LOGGER.debug("No statistics metadata found for %s (new sensor)", entity_id)
+            return True
+
+        if decimal:
+            decimal_unit = '0.1' + UnitOfTemperature.CELSIUS
+            if unit != decimal_unit:
+                # Called from the event loop as required
+                async_change_statistics_unit(
+                    hass,
+                    entity_id,
+                    new_unit_of_measurement=decimal_unit,
+                    old_unit_of_measurement=unit,
+                )
+            else:
+                _LOGGER.debug("No unit change needed for %s", entity_id)
+        return True
     except Exception as e:
         _LOGGER.error("Could not update celsius for %s: %s", entity_id, str(e), exc_info=True)
         return False
@@ -553,7 +560,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def handle_hass_started(_event: Event) -> None:
         """Event handler for when HA has started."""
-        await hass.async_create_task(heatpump.setup_mqtt())
+        await heatpump.setup_mqtt()
 
     # One common ThermIQWorker serves all HeatPump objects
     if DOMAIN in hass.data:
@@ -566,17 +573,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Make config reload
     rld = entry.add_update_listener(reload_entry)
     entry.async_on_unload(rld)
-    hass.async_create_task(setup_input_numbers(heatpump))
-    hass.async_create_task(setup_input_selects(heatpump))
-    hass.async_create_task(setup_input_booleans(heatpump))
+
+    async def finish_setup() -> None:
+        """Create the input_* helper entities, then start MQTT."""
+        await setup_input_numbers(heatpump)
+        await setup_input_selects(heatpump)
+        await setup_input_booleans(heatpump)
+        if hass.is_running:
+            # HA is already up (e.g. the integration was just added via the
+            # UI) - EVENT_HOMEASSISTANT_STARTED has fired and never will
+            # again, so subscribe immediately
+            await heatpump.setup_mqtt()
+        else:
+            # Wait for hass to start before subscribing
+            hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_STARTED, handle_hass_started
+            )
+
+    hass.async_create_task(finish_setup())
 
     # Load the sensor/binary_sensor platforms and await them so the entities
     # are fully set up before this entry is marked done (avoids races where
     # consumers access the platform data before it is ready)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    # Wait for hass to start and then add the input_* entities
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, handle_hass_started)
 
     return True
 
@@ -586,6 +605,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         worker = hass.data[DOMAIN]
+        # Unsubscribe MQTT and remove the generated helper entities so a
+        # reload does not leak subscriptions or orphan input_* entities
+        heatpump = worker.heatpumps.get(entry.data[CONF_ID])
+        if heatpump is not None:
+            await heatpump.async_reset()
         worker.remove_entry(entry)
         if worker.is_idle():
             # also remove worker if not used by any entry any more

--- a/custom_components/thermiq_mqtt/binary_sensor.py
+++ b/custom_components/thermiq_mqtt/binary_sensor.py
@@ -1,29 +1,18 @@
 import logging
-from numbers import Number
-from typing import TYPE_CHECKING, Literal, final
 from homeassistant.core import HomeAssistant, callback
 
-from homeassistant.const import STATE_OFF, STATE_ON
-
 from homeassistant.components.binary_sensor import (
-    BinarySensorDeviceClass,
     BinarySensorEntity,
-    BinarySensorEntityDescription,
 )
 from homeassistant.const import (
     ATTR_IDENTIFIERS,
     ATTR_MANUFACTURER,
     ATTR_MODEL,
     ATTR_NAME,
-    STATE_OFF,
-    STATE_ON,
-    EntityCategory)
+)
 
 from homeassistant.helpers.device_registry import DeviceEntryType
 
-from homeassistant.const import (
-    PERCENTAGE
-)
 from .const import (
     DOMAIN,
     MANUFACTURER,
@@ -42,9 +31,6 @@ from .heatpump.thermiq_regs import (
     id_names,
     reg_id,
 )
-
-
-from functools import cached_property
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -121,17 +107,11 @@ class HeatPumpBinarySensor(BinarySensorEntity):
         self._idx = device_id
         self._vp_reg = vp_reg
         self._bitmask = bitmask
-        # ???
-        if isinstance(vp_reg,Number):
-            self._sorter = int("0x" + vp_reg[1:], 0) * 65536 + int(bitmask)
-        else:
-            self._sorter = 256 * 65536 + int(bitmask)
-
-        # Listen for the ThermIQ rec event indicating new data
-        hass.bus.async_listen(
-            heatpump._domain + "_" + heatpump._id + "_msg_rec_event",
-            self._async_update_event,
-        )
+        # Sort key: register number (hex string like 'r10') then bitmask
+        try:
+            self._sorter = int(vp_reg[1:], 16) * 65536 + int(bitmask)
+        except (TypeError, ValueError):
+            self._sorter = 256 * 65536
 
         # This is needed
         self._attr_device_info = {
@@ -143,6 +123,18 @@ class HeatPumpBinarySensor(BinarySensorEntity):
         }
 
 
+    async def async_added_to_hass(self):
+        """Register the update listener; removed automatically on unload."""
+        self.async_on_remove(
+            self.hass.bus.async_listen(
+                self._heatpump._domain
+                + "_"
+                + self._heatpump._id
+                + "_msg_rec_event",
+                self._async_update_event,
+            )
+        )
+
     @property
     def name(self):
         """Return the name of the sensor."""
@@ -153,24 +145,14 @@ class HeatPumpBinarySensor(BinarySensorEntity):
         """No need to poll. Coordinator notifies entity of updates."""
         return False
 
-    @final
-    @property
-    def state(self) -> Literal["on", "off"]:
-        """Return the state of the sensor."""
-        return STATE_ON if (self._state) else STATE_OFF
-
     @property
     def vp_reg(self):
-        """Return the device class of the sensor."""
+        """Return the register of the sensor."""
         return self._vp_reg
-
-    @cached_property
-    def is_on(self) -> bool:
-        return (self._state==True)
 
     @property
     def sorter(self):
-        """Return the state of the sensor."""
+        """Return the sort key of the sensor."""
         return self._sorter
 
     @property
@@ -179,12 +161,11 @@ class HeatPumpBinarySensor(BinarySensorEntity):
         return self._icon
 
     async def async_update(self):
-        """Update the value of the entity."""
         """Update the new state of the sensor."""
 
         _LOGGER.debug("update: " + self._idx)
-        reg_state = self._hpstate[self._vp_reg]
-        if self._state is None:
+        reg_state = self._hpstate.get(self._vp_reg)
+        if reg_state is None:
             _LOGGER.warning("Could not get data for %s", self._idx)
         else:
             self._state = (int(reg_state) & self._bitmask) > 0
@@ -196,22 +177,19 @@ class HeatPumpBinarySensor(BinarySensorEntity):
         _LOGGER.debug("event: " + self._idx)
         if self._vp_reg=='evu':
             _LOGGER.debug("EVU reg state read special")
-        reg_state = self._hpstate[self._vp_reg]
+        reg_state = self._hpstate.get(self._vp_reg)
         if reg_state is None:
             _LOGGER.debug("Could not get data for %s", self._idx)
-            self._state = None
             bool_state = None
-            self._attr_is_on = False
         else:
-            bool_state = (int(reg_state) & self._bitmask) > 0
+            try:
+                bool_state = (int(reg_state) & self._bitmask) > 0
+            except (TypeError, ValueError):
+                _LOGGER.debug("Non-numeric data for %s: [%s]", self._idx, reg_state)
+                bool_state = None
 
         if self._state != bool_state:
             self._state = bool_state
-            self._attr_is_on = self._state
+            self._attr_is_on = bool(bool_state)
             self.async_schedule_update_ha_state()
             _LOGGER.debug("async_update_ha: %s: [%s]",self._idx, str(bool_state))
-
-    @property
-    def device_class(self):
-        """Return the class of this device."""
-        return f"{DOMAIN}_HeatPumpSensor"

--- a/custom_components/thermiq_mqtt/binary_sensor.py
+++ b/custom_components/thermiq_mqtt/binary_sensor.py
@@ -1,29 +1,19 @@
 import logging
-from numbers import Number
-from typing import TYPE_CHECKING, Literal, final
 from homeassistant.core import HomeAssistant, callback
-
-from homeassistant.const import STATE_OFF, STATE_ON
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
-    BinarySensorEntityDescription,
 )
 from homeassistant.const import (
     ATTR_IDENTIFIERS,
     ATTR_MANUFACTURER,
     ATTR_MODEL,
     ATTR_NAME,
-    STATE_OFF,
-    STATE_ON,
-    EntityCategory)
+)
 
 from homeassistant.helpers.device_registry import DeviceEntryType
 
-from homeassistant.const import (
-    PERCENTAGE
-)
 from .const import (
     DOMAIN,
     MANUFACTURER,
@@ -42,9 +32,6 @@ from .heatpump.thermiq_regs import (
     id_names,
     reg_id,
 )
-
-
-from functools import cached_property
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -160,17 +147,11 @@ class HeatPumpBinarySensor(BinarySensorEntity):
         self._idx = device_id
         self._vp_reg = vp_reg
         self._bitmask = bitmask
-        # ???
-        if isinstance(vp_reg,Number):
-            self._sorter = int("0x" + vp_reg[1:], 0) * 65536 + int(bitmask)
-        else:
-            self._sorter = 256 * 65536 + int(bitmask)
-
-        # Listen for the ThermIQ rec event indicating new data
-        hass.bus.async_listen(
-            heatpump._domain + "_" + heatpump._id + "_msg_rec_event",
-            self._async_update_event,
-        )
+        # Sort key: register number (hex string like 'r10') then bitmask
+        try:
+            self._sorter = int(vp_reg[1:], 16) * 65536 + int(bitmask)
+        except (TypeError, ValueError):
+            self._sorter = 256 * 65536
 
         # This is needed
         self._attr_device_info = {
@@ -182,6 +163,18 @@ class HeatPumpBinarySensor(BinarySensorEntity):
         }
 
 
+    async def async_added_to_hass(self):
+        """Register the update listener; removed automatically on unload."""
+        self.async_on_remove(
+            self.hass.bus.async_listen(
+                self._heatpump._domain
+                + "_"
+                + self._heatpump._id
+                + "_msg_rec_event",
+                self._async_update_event,
+            )
+        )
+
     @property
     def name(self):
         """Return the name of the sensor."""
@@ -192,15 +185,9 @@ class HeatPumpBinarySensor(BinarySensorEntity):
         """No need to poll. Coordinator notifies entity of updates."""
         return False
 
-    @final
-    @property
-    def state(self) -> Literal["on", "off"]:
-        """Return the state of the sensor."""
-        return STATE_ON if (self._state) else STATE_OFF
-
     @property
     def vp_reg(self):
-        """Return the device class of the sensor."""
+        """Return the register of the sensor."""
         return self._vp_reg
 
     @property
@@ -218,12 +205,11 @@ class HeatPumpBinarySensor(BinarySensorEntity):
         return self._icon
 
     async def async_update(self):
-        """Update the value of the entity."""
         """Update the new state of the sensor."""
 
         _LOGGER.debug("update: " + self._idx)
-        reg_state = self._hpstate[self._vp_reg]
-        if self._state is None:
+        reg_state = self._hpstate.get(self._vp_reg)
+        if reg_state is None:
             _LOGGER.warning("Could not get data for %s", self._idx)
         else:
             self._state = (int(reg_state) & self._bitmask) > 0
@@ -235,21 +221,24 @@ class HeatPumpBinarySensor(BinarySensorEntity):
         _LOGGER.debug("event: " + self._idx)
         if self._vp_reg=='evu':
             _LOGGER.debug("EVU reg state read special")
-        reg_state = self._hpstate[self._vp_reg]
+        reg_state = self._hpstate.get(self._vp_reg)
         if reg_state is None:
             _LOGGER.debug("Could not get data for %s", self._idx)
-            self._state = None
             bool_state = None
-            self._attr_is_on = False
         else:
-            bool_state = (int(reg_state) & self._bitmask) > 0
+            try:
+                bool_state = (int(reg_state) & self._bitmask) > 0
+            except (TypeError, ValueError):
+                _LOGGER.debug("Non-numeric data for %s: [%s]", self._idx, reg_state)
+                bool_state = None
 
         if self._state != bool_state:
             self._state = bool_state
-            self._attr_is_on = self._state
+            self._attr_is_on = bool(bool_state)
             self.async_schedule_update_ha_state()
             _LOGGER.debug("async_update_ha: %s: [%s]",self._idx, str(bool_state))
 
-def device_class(self):
+    @property
+    def device_class(self):
         """Return the class of this device."""
         return _DEVICE_CLASS_MAP.get(self._idx)

--- a/custom_components/thermiq_mqtt/input_boolean.py
+++ b/custom_components/thermiq_mqtt/input_boolean.py
@@ -130,6 +130,8 @@ async def update_input_boolean(heatpump) -> None:
 #            )
 
     await platform.async_add_entities(to_add)
+    # Track for removal on config entry unload
+    heatpump._helper_entities.extend(to_add)
     platform.async_register_entity_service(SERVICE_SET_VALUE,{ vol.Required('value'): vol.Coerce(bool)}, "async_set_value")
 
 

--- a/custom_components/thermiq_mqtt/input_number.py
+++ b/custom_components/thermiq_mqtt/input_number.py
@@ -78,7 +78,10 @@ class CustomInputNumber(InputNumber):
         await super().async_set_value(value)
         _LOGGER.debug("async_set: " + self.entity_id)
         # is value updated by GUI?
-        if self.heatpump._hpstate["mqtt_counter"] > -1:
+        # Only send MQTT once we have received data from the heatpump,
+        # otherwise a GUI touch before the first message would write
+        # uninitialized values to the pump
+        if self.heatpump._hpstate["mqtt_counter"] > 0:
             if value != self.heatpump._hpstate[self.reg]:
                 self.heatpump._hpstate[self.reg] = value
                 self.heatpump._hass.bus.fire(
@@ -119,6 +122,8 @@ async def update_input_numbers(heatpump) -> None:
             )
 
     await platform.async_add_entities(to_add)
+    # Track for removal on config entry unload
+    heatpump._helper_entities.extend(to_add)
 
 
 def create_input_number_entity(heatpump, name, value) -> CustomInputNumber:
@@ -170,6 +175,6 @@ def create_input_number_entity(heatpump, name, value) -> CustomInputNumber:
 
     _LOGGER.debug("entity_id:" + entity.entity_id)
     if value is not None:
-        _LOGGER.debug("value:" + value)
+        _LOGGER.debug("value: %s", value)
 
     return entity

--- a/custom_components/thermiq_mqtt/input_number.py
+++ b/custom_components/thermiq_mqtt/input_number.py
@@ -78,7 +78,10 @@ class CustomInputNumber(InputNumber):
         await super().async_set_native_value(value)
         _LOGGER.debug("async_set: " + self.entity_id)
         # is value updated by GUI?
-        if self.heatpump._hpstate["mqtt_counter"] > -1:
+        # Only send MQTT once we have received data from the heatpump,
+        # otherwise a GUI touch before the first message would write
+        # uninitialized values to the pump
+        if self.heatpump._hpstate["mqtt_counter"] > 0:
             if value != self.heatpump._hpstate[self.reg]:
                 self.heatpump._hpstate[self.reg] = value
                 self.heatpump._hass.bus.fire(
@@ -119,6 +122,8 @@ async def update_input_numbers(heatpump) -> None:
             )
 
     await platform.async_add_entities(to_add)
+    # Track for removal on config entry unload
+    heatpump._helper_entities.extend(to_add)
 
 
 def create_input_number_entity(heatpump, name, value) -> CustomInputNumber:
@@ -170,6 +175,6 @@ def create_input_number_entity(heatpump, name, value) -> CustomInputNumber:
 
     _LOGGER.debug("entity_id:" + entity.entity_id)
     if value is not None:
-        _LOGGER.debug("value:" + value)
+        _LOGGER.debug("value: %s", value)
 
     return entity

--- a/custom_components/thermiq_mqtt/input_select.py
+++ b/custom_components/thermiq_mqtt/input_select.py
@@ -86,6 +86,8 @@ async def update_input_select(heatpump) -> None:
             )
 
     await platform.async_add_entities(to_add)
+    # Track for removal on config entry unload
+    heatpump._helper_entities.extend(to_add)
 
 
 def create_input_select_entity(heatpump, name) -> CustomInputSelect:

--- a/custom_components/thermiq_mqtt/sensor.py
+++ b/custom_components/thermiq_mqtt/sensor.py
@@ -178,15 +178,6 @@ class HeatPumpSensor(SensorEntity):
         self._idx = device_id
         self._vp_reg = vp_reg
 
-        # self.device_class [temperature, voltage,
-        #self.state_class= measurement
-
-        # Listen for the ThermIQ rec event indicating new data
-        hass.bus.async_listen(
-            heatpump._domain + "_" + heatpump._id + "_msg_rec_event",
-            self._async_update_event,
-        )
-
         # This is needed
         self._attr_device_info = {
             ATTR_IDENTIFIERS: {(DOMAIN,heatpump._id)},
@@ -197,6 +188,18 @@ class HeatPumpSensor(SensorEntity):
         }
 
 
+
+    async def async_added_to_hass(self):
+        """Register the update listener; removed automatically on unload."""
+        self.async_on_remove(
+            self.hass.bus.async_listen(
+                self._heatpump._domain
+                + "_"
+                + self._heatpump._id
+                + "_msg_rec_event",
+                self._async_update_event,
+            )
+        )
 
     @property
     def name(self):
@@ -230,10 +233,9 @@ class HeatPumpSensor(SensorEntity):
 
     async def async_update(self):
         """Update the value of the entity."""
-        """Update the new state of the sensor."""
 
         _LOGGER.debug("update: " + self._idx)
-        self._state = self._hpstate.get_value(self._vp_reg)
+        self._state = self._hpstate.get(self._vp_reg)
         if self._state is None:
             _LOGGER.warning("Could not get data for %s", self._idx)
 
@@ -241,15 +243,10 @@ class HeatPumpSensor(SensorEntity):
         """Update the new state of the sensor."""
 
         _LOGGER.debug("event: " + self._idx)
-        state = self._hpstate[self._vp_reg]
+        state = self._hpstate.get(self._vp_reg)
         if state is None:
             _LOGGER.debug("Could not get data for %s", self._idx)
         if self._state != state:
             self._state = state
             self.async_schedule_update_ha_state()
             _LOGGER.debug("async_update_ha: %s", str(state))
-
-    @property
-    def device_class(self):
-        """Return the class of this device."""
-        return f"{DOMAIN}_HeatPumpSensor"

--- a/custom_components/thermiq_mqtt/sensor.py
+++ b/custom_components/thermiq_mqtt/sensor.py
@@ -178,15 +178,6 @@ class HeatPumpSensor(SensorEntity):
         self._idx = device_id
         self._vp_reg = vp_reg
 
-        # self.device_class [temperature, voltage,
-        #self.state_class= measurement
-
-        # Listen for the ThermIQ rec event indicating new data
-        hass.bus.async_listen(
-            heatpump._domain + "_" + heatpump._id + "_msg_rec_event",
-            self._async_update_event,
-        )
-
         # This is needed
         self._attr_device_info = {
             ATTR_IDENTIFIERS: {(DOMAIN,heatpump._id)},
@@ -197,6 +188,18 @@ class HeatPumpSensor(SensorEntity):
         }
 
 
+
+    async def async_added_to_hass(self):
+        """Register the update listener; removed automatically on unload."""
+        self.async_on_remove(
+            self.hass.bus.async_listen(
+                self._heatpump._domain
+                + "_"
+                + self._heatpump._id
+                + "_msg_rec_event",
+                self._async_update_event,
+            )
+        )
 
     @property
     def name(self):
@@ -230,10 +233,9 @@ class HeatPumpSensor(SensorEntity):
 
     async def async_update(self):
         """Update the value of the entity."""
-        """Update the new state of the sensor."""
 
         _LOGGER.debug("update: " + self._idx)
-        self._state = self._hpstate.get_value(self._vp_reg)
+        self._state = self._hpstate.get(self._vp_reg)
         if self._state is None:
             _LOGGER.warning("Could not get data for %s", self._idx)
 
@@ -241,15 +243,10 @@ class HeatPumpSensor(SensorEntity):
         """Update the new state of the sensor."""
 
         _LOGGER.debug("event: " + self._idx)
-        state = self._hpstate[self._vp_reg]
+        state = self._hpstate.get(self._vp_reg)
         if state is None:
             _LOGGER.debug("Could not get data for %s", self._idx)
         if self._state != state:
             self._state = state
             self.async_schedule_update_ha_state()
             _LOGGER.debug("async_update_ha: %s", str(state))
-
-#    @property
-#    def device_class(self):
-#        """Return the class of this device."""
-#        return f"{DOMAIN}_HeatPumpSensor"


### PR DESCRIPTION
Part of #79.

**Symptom:** Adding the integration via the UI on a running HA never receives any data; reloading/removing the entry leaks resources.

**Cause & fixes (three commits):**

1. **Runtime setup never subscribes to MQTT.** Setup waits for `EVENT_HOMEASSISTANT_STARTED`, which has already fired when an entry is added via the UI. Now subscribes immediately when `hass.is_running`, and only waits for the event during HA startup.
2. **Unload leaks.** Unloading an entry left the MQTT subscription, the update listeners, and the generated input_* helper entities behind; reloading then doubled them. Entities are now tracked and removed, and the subscription is cleaned up in `async_reset()`. Also fixes the dead wait-for-data guard in the input_* setup (compared against the `-1`/None seed incorrectly).
3. **Migration executor bugs.** `async_add_executor_job(...)` was not awaited (result discarded, races with setup), and `async_change_statistics_unit` — a loop-only API — was called from inside the executor job. The DB work now runs in the recorder executor and the loop-only call happens on the event loop. Also fixes sensor/binary_sensor `device_class` being overridden with a garbage string (`f"{DOMAIN}_HeatPumpSensor"`), which broke temperature device classes, and the `cached_property is_on` that froze binary sensor states.

**Verified:** on a live pump — add-via-UI receives data immediately; entry reload test shows no duplicate subscriptions/entities; migration runs clean; temperature sensors get proper device_class again.
