### PR TITLE
Await platform setup to avoid setup races

### DIFF
--- a/custom_components/thermiq_mqtt/__init__.py
+++ b/custom_components/thermiq_mqtt/__init__.py
@@ -522,10 +522,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.async_create_task(setup_input_selects(heatpump))
     hass.async_create_task(setup_input_booleans(heatpump))
 
-    # Load the platforms for heatpump
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    )
+    # Load the sensor/binary_sensor platforms and await them so the entities
+    # are fully set up before this entry is marked done (avoids races where
+    # consumers access the platform data before it is ready)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     # Wait for hass to start and then add the input_* entities
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, handle_hass_started)


### PR DESCRIPTION
Part of #79.

**Symptom:** Rare setup races where consumers touch platform data before the sensor/binary_sensor platforms are set up.

**Cause:** `async_forward_entry_setups` is launched with `hass.async_create_task(...)` — fire-and-forget — so `async_setup_entry` returns (and the entry is marked loaded) before the platforms finish. HA docs require awaiting it.

**Fix:** `await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)`. One-line change, no behavior change beyond correct ordering.
