### PR TITLE
Translations: real Swedish, add German/Finnish/Norwegian

### DIFF
--- a/custom_components/thermiq_mqtt/translations/de.json
+++ b/custom_components/thermiq_mqtt/translations/de.json
@@ -1,0 +1,45 @@
+{
+  "config": {
+    "flow_title": "ThermIQ MQTT",
+    "abort": {
+      "already_configured": "Der eingegebene ID-Name wird bereits verwendet."
+    },
+    "error": {
+      "invalid_nodename": "Der eingegebene MQTT-Knotenname ist ungültig",
+      "creation_id": "Die eindeutige ID ist nicht eindeutig oder ungültig",
+      "creation_error": "Beim Aktualisieren des Konfigurationsobjekts ist ein Fehler aufgetreten",
+      "invalid_language": "Beim Erstellen des Konfigurationsobjekts ist ein Fehler aufgetreten"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "id_name": "Eindeutige ID",
+          "mqtt_node": "MQTT-Knotenname",
+          "language": "Sprache",
+          "hexformat": "Hexformat für Register in MQTT verwenden",
+          "thermiq_dbg": "MQTT-Debug aktivieren (Schreibvorgänge werden auf dbg-Topic umgeleitet)",
+          "migrate_data": "Migration alter Daten in der Recorder-Datenbank anfordern (kann dauern)"
+        },
+        "title": "Wärmepumpen-Konfiguration",
+        "description": "Eine neue ThermIQ_MQTT-Instanz einrichten"
+      }
+    }
+  },
+  "options": {
+    "abort": {
+      "already_configured": "Der eingegebene ID-Name wird bereits verwendet."
+    },
+    "step": {
+      "user": {
+        "data": {
+          "mqtt_node": "MQTT-Knotenname",
+          "language": "Sprache",
+          "hexformat": "Hexformat für Register in MQTT verwenden",
+          "thermiq_dbg": "MQTT-Debug aktivieren (Schreibvorgänge werden auf dbg-Topic umgeleitet)",
+          "migrate_data": "Migration alter Daten in der Recorder-Datenbank anfordern (kann dauern)"
+        },
+        "title": "Optionen"
+      }
+    }
+  }
+}

--- a/custom_components/thermiq_mqtt/translations/en.json
+++ b/custom_components/thermiq_mqtt/translations/en.json
@@ -16,7 +16,7 @@
           "id_name": "Unique ID",
           "mqtt_node": "MQTT Nodename",
           "language": "Language",
-          "hexformat": "Use hexformat for registers i MQTT",
+          "hexformat": "Use hexformat for registers in MQTT",
           "thermiq_dbg": "Enable MQTT debug by adding '_dbg' to Nodename",
           "migrate_data": "Request migration of old data in recorder database (may take time)"
         },
@@ -37,7 +37,7 @@
         "data": {
           "mqtt_node": "MQTT Nodename",
           "language": "Language",
-          "hexformat": "Use hexformat for registers i MQTT",
+          "hexformat": "Use hexformat for registers in MQTT",
           "thermiq_dbg": "Enable MQTT debug by adding '_dbg' to Nodename",
           "migrate_data": "Request migration of old data in recorder database (may take time)"
         },

--- a/custom_components/thermiq_mqtt/translations/fi.json
+++ b/custom_components/thermiq_mqtt/translations/fi.json
@@ -1,0 +1,45 @@
+{
+  "config": {
+    "flow_title": "ThermIQ MQTT",
+    "abort": {
+      "already_configured": "Annettu tunnus on jo käytössä."
+    },
+    "error": {
+      "invalid_nodename": "Annettu MQTT-solmun nimi ei kelpaa",
+      "creation_id": "Yksilöllinen tunnus ei ole yksilöllinen tai kelvollinen",
+      "creation_error": "Virhe päivitettäessä määritysobjektia",
+      "invalid_language": "Virhe luotaessa määritysobjektia"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "id_name": "Yksilöllinen tunnus",
+          "mqtt_node": "MQTT-solmun nimi",
+          "language": "Kieli",
+          "hexformat": "Käytä heksamuotoa MQTT-rekistereille",
+          "thermiq_dbg": "Ota MQTT-vianetsintä käyttöön (kirjoitukset ohjataan dbg-aiheeseen)",
+          "migrate_data": "Pyydä vanhojen tietojen siirtoa recorder-tietokannassa (voi kestää)"
+        },
+        "title": "Lämpöpumpun määritykset",
+        "description": "Määritä uusi ThermIQ_MQTT-instanssi"
+      }
+    }
+  },
+  "options": {
+    "abort": {
+      "already_configured": "Annettu tunnus on jo käytössä."
+    },
+    "step": {
+      "user": {
+        "data": {
+          "mqtt_node": "MQTT-solmun nimi",
+          "language": "Kieli",
+          "hexformat": "Käytä heksamuotoa MQTT-rekistereille",
+          "thermiq_dbg": "Ota MQTT-vianetsintä käyttöön (kirjoitukset ohjataan dbg-aiheeseen)",
+          "migrate_data": "Pyydä vanhojen tietojen siirtoa recorder-tietokannassa (voi kestää)"
+        },
+        "title": "Asetukset"
+      }
+    }
+  }
+}

--- a/custom_components/thermiq_mqtt/translations/no.json
+++ b/custom_components/thermiq_mqtt/translations/no.json
@@ -1,0 +1,45 @@
+{
+  "config": {
+    "flow_title": "ThermIQ MQTT",
+    "abort": {
+      "already_configured": "Det angitte ID-navnet er allerede i bruk."
+    },
+    "error": {
+      "invalid_nodename": "Det angitte MQTT-nodenavnet er ugyldig",
+      "creation_id": "Den unike ID-en er ikke unik eller ugyldig",
+      "creation_error": "Det oppstod en feil under oppdatering av konfigurasjonsobjektet",
+      "invalid_language": "Det oppstod en feil under oppretting av konfigurasjonsobjektet"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "id_name": "Unik ID",
+          "mqtt_node": "MQTT-nodenavn",
+          "language": "Språk",
+          "hexformat": "Bruk hexformat for registre i MQTT",
+          "thermiq_dbg": "Aktiver MQTT-feilsøking (skrivinger omdirigeres til dbg-emne)",
+          "migrate_data": "Be om migrering av gamle data i recorder-databasen (kan ta tid)"
+        },
+        "title": "Varmepumpekonfigurasjon",
+        "description": "Sett opp en ny ThermIQ_MQTT-instans"
+      }
+    }
+  },
+  "options": {
+    "abort": {
+      "already_configured": "Det angitte ID-navnet er allerede i bruk."
+    },
+    "step": {
+      "user": {
+        "data": {
+          "mqtt_node": "MQTT-nodenavn",
+          "language": "Språk",
+          "hexformat": "Bruk hexformat for registre i MQTT",
+          "thermiq_dbg": "Aktiver MQTT-feilsøking (skrivinger omdirigeres til dbg-emne)",
+          "migrate_data": "Be om migrering av gamle data i recorder-databasen (kan ta tid)"
+        },
+        "title": "Alternativer"
+      }
+    }
+  }
+}

--- a/custom_components/thermiq_mqtt/translations/se.json
+++ b/custom_components/thermiq_mqtt/translations/se.json
@@ -1,47 +1,44 @@
 {
   "config": {
-    "flow_title": "Flow title",
+    "flow_title": "ThermIQ MQTT",
     "abort": {
-      "already_configured": "The entered id name is already in use."
+      "already_configured": "Det angivna ID-namnet används redan."
     },
     "error": {
-      "invalid_nodename": "The entered MQTT Nodename is not valid",
-      "creation_id": "The Unique ID is not Unique or not valid",
-      "creation_error": "An error occured while updating configuration object",
-      "invalid_language": "An error occured while creating configuration object"
+      "invalid_nodename": "Det angivna MQTT-nodnamnet är ogiltigt",
+      "creation_id": "Det unika ID:t är inte unikt eller ogiltigt",
+      "creation_error": "Ett fel uppstod när konfigurationsobjektet uppdaterades",
+      "invalid_language": "Ett fel uppstod när konfigurationsobjektet skapades"
     },
     "step": {
       "user": {
         "data": {
-          "id_name": "Unique ID",
-          "mqtt_node": "MQTT Nodename",
-          "language": "Language",
-          "hexformat": "Use hexformat for registers i MQTT",
-          "thermiq_dbg": "Enable debug",
-          "migrate_data": "Request migration of old data in recorder database (may take time)"
+          "id_name": "Unikt ID",
+          "mqtt_node": "MQTT-nodnamn",
+          "language": "Språk",
+          "hexformat": "Använd hexformat för register i MQTT",
+          "thermiq_dbg": "Aktivera MQTT-felsökning (skrivningar styrs om till dbg-topic)",
+          "migrate_data": "Begär migrering av gammal data i recorder-databasen (kan ta tid)"
         },
-        "title": "Heatpump config",
-        "description": "Set up a new ThermIQ_MQTT Instance"
+        "title": "Värmepumpskonfiguration",
+        "description": "Konfigurera en ny ThermIQ_MQTT-instans"
       }
-    },
-    "progress": {
-      "slow_task": "This message will be displayed if `slow_task` is returned as `progress_action` for `async_show_progress`."
     }
   },
   "options": {
     "abort": {
-      "already_configured": "The entered id name is already in use."
+      "already_configured": "Det angivna ID-namnet används redan."
     },
     "step": {
       "user": {
         "data": {
-          "mqtt_node": "MQTT Nodename",
-          "language": "Language",
-          "hexformat": "Use hexformat for registers i MQTT",
-          "thermiq_dbg": "Enable debug",
-          "migrate_data": "Request migration of old data in recorder database (may take time)"
+          "mqtt_node": "MQTT-nodnamn",
+          "language": "Språk",
+          "hexformat": "Använd hexformat för register i MQTT",
+          "thermiq_dbg": "Aktivera MQTT-felsökning (skrivningar styrs om till dbg-topic)",
+          "migrate_data": "Begär migrering av gammal data i recorder-databasen (kan ta tid)"
         },
-        "title": "Options"
+        "title": "Alternativ"
       }
     }
   }


### PR DESCRIPTION
Part of #79.

`translations/se.json` contained the English strings. This adds a real Swedish translation and new `de.json`, `fi.json`, `no.json` config-flow translations (the integration already offers these languages for entity labels via the register table, so the config flow now matches).
