### PR TITLE
CI: update the actions, pin black, and make the style job report something

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: "ubuntu-latest"
     name: Validate
     steps:
-        - uses: "actions/checkout@v2"
+        - uses: "actions/checkout@v4"
 
         - name: HACS validation
           uses: "hacs/action@main"

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: "ubuntu-latest"
     name: Validate
     steps:
-        - uses: "actions/checkout@v2"
+        - uses: "actions/checkout@v4"
         - name: HACS validation
           uses: "hacs/action@main"
           with:
@@ -26,11 +26,21 @@ jobs:
     runs-on: "ubuntu-latest"
     name: Check style formatting
     steps:
-        - uses: "actions/checkout@v2"
-        - uses: "actions/setup-python@v1"
+        - uses: "actions/checkout@v4"
+        - uses: "actions/setup-python@v5"
           with:
             python-version: "3.x"
-        - run: python3 -m pip install black
-        - run: black .
+        # Pinned: an unpinned black turns CI red on its own the day a new
+        # release changes its formatting, with no commit to blame.
+        - run: python3 -m pip install "black==25.11.0"
+        # --check reports instead of reformatting into a runner that is then
+        # thrown away; --diff shows exactly what it would change.
+        #
+        # Not blocking yet, deliberately: every file in this repository would
+        # be reformatted today, so making this red would mean a reformatting
+        # commit nobody asked for. Drop this line once that pass has happened
+        # and the job starts meaning something.
+        - run: black --check --diff .
+          continue-on-error: true
 
   


### PR DESCRIPTION
The CI suggestions from #79, rebased onto your master. **The `pull_request:` trigger this PR originally added is gone — you added it yourself, so it is no longer needed here.**

Three things left, in `.github/workflows/`:

### 1. The actions are several generations behind

`actions/checkout@v2` and `actions/setup-python@v1` run on a Node runtime GitHub is retiring — they emit deprecation warnings today and will eventually stop working. Bumped to `@v4` and `@v5`, in `cron.yaml` as well as `push.yaml`.

### 2. `black` was unpinned

The day a release changes its formatting, CI goes red with no commit to blame for it. Pinned to `25.11.0`.

### 3. The style job could not fail

`black .` reformats files inside the runner and throws the result away. The only way it fails is if a file won't parse. It now runs `--check --diff`, so the log shows exactly what it would change.

**Deliberately non-blocking.** In #79 I said I'd scope the check to a subdirectory rather than reformat everything at once. Having measured it properly: all ten Python files here would be reformatted, so there is no already-clean corner to scope to. `continue-on-error: true` keeps the job green while making its output visible — you can see what black thinks without it blocking anything. Delete that one line whenever the formatting pass has happened and the job starts meaning something.

Happy to send that formatting pass as its own PR whenever you want it, and equally happy if you'd rather leave the formatting alone — it makes `git blame` worse for a while, so it's your call rather than mine.

---

**What this does not do,** so I'm not overselling it: it wouldn't have caught either thing that went wrong in your last merge. A `device_class` that lost its `@property` and got dedented out of the class is still valid Python, and `config_flow.py` with CR-only line endings still compiles. Tests would have caught the first — that's an argument for #78, not for this.
