### PR TITLE
CI: update the actions, and make the style job report something

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: "ubuntu-latest"
     name: Validate
     steps:
-        - uses: "actions/checkout@v2"
+        - uses: "actions/checkout@v4"
         - name: HACS validation
           uses: "hacs/action@main"
           with:
@@ -26,11 +26,21 @@ jobs:
     runs-on: "ubuntu-latest"
     name: Check style formatting
     steps:
-        - uses: "actions/checkout@v2"
-        - uses: "actions/setup-python@v1"
+        - uses: "actions/checkout@v4"
+        - uses: "actions/setup-python@v5"
           with:
             python-version: "3.x"
-        - run: python3 -m pip install black
-        - run: black .
+        # Pinned: an unpinned black turns CI red on its own the day a new
+        # release changes its formatting, with no commit to blame.
+        - run: python3 -m pip install "black==25.11.0"
+        # --check reports instead of reformatting into a runner that is then
+        # thrown away; --diff shows exactly what it would change.
+        #
+        # Not blocking yet, deliberately: every file in this repository would
+        # be reformatted today, and turning this red would mean a
+        # reformatting commit nobody asked for. Drop this line whenever the
+        # formatting pass has happened and the job starts meaning something.
+        - run: black --check --diff .
+          continue-on-error: true
 
   


### PR DESCRIPTION
The rest of the CI suggestions from #79, as its own small PR since you said you'd take it. The trigger you already added yourself, so this doesn't touch it.

Three things, all in `.github/workflows/push.yaml`:

**The actions are several generations behind.** `checkout@v2` and `setup-python@v1` run on a Node version GitHub is retiring — they warn today and stop working eventually. `@v4` and `@v5` are drop-in here.

**`black` was unpinned.** The day a release changes its formatting, CI goes red with no commit to blame for it. Pinned to `25.11.0`.

**The style job could not fail.** `black .` reformats files inside the runner and throws the result away; the only way it fails is if a file won't parse. It now runs `--check --diff`, so the log shows exactly what it would change.

## On that last one — it is deliberately not blocking

I said in #79 that I'd scope the check to a subdirectory rather than reformat everything at once. Having looked properly, there's nothing to scope it to: **all ten Python files here would be reformatted**, so any blocking `--check` means a reformatting commit you didn't ask for.

So `continue-on-error: true` keeps the job green while making its output visible. You can see what black thinks without it standing in your way. Delete that one line whenever the formatting pass has happened and the job starts meaning something.

Happy to send that formatting pass as its own PR whenever you want it — and equally happy if you'd rather leave the formatting alone. It's the kind of change that makes `git blame` worse for a while, so it's genuinely your call rather than mine.

## What this does not do

It won't catch what went wrong in your last merge. A `device_class` that lost its `@property` and got dedented out of the class is still valid Python, and CR-only line endings still compile. Tests would have caught the first one — that's an argument for #78, not for this.