### PR TITLE
CI: restore the repo-wide formatting report that the #78 merge dropped

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -34,9 +34,18 @@ jobs:
             python-version: "3.12"
         # pinned so a new black release cannot turn CI red on its own
         - run: python3 -m pip install black==25.11.0
-        # only the tests this PR adds - reformatting the whole
-        # codebase would be a large unrelated diff
+        # Blocking, but only over tests/ - those files are already formatted,
+        # so keeping them that way costs nothing. Reformatting the whole
+        # codebase would be a large unrelated diff.
         - run: black --check tests/
+        # Reporting only, never blocking: --diff prints exactly what black
+        # would change in the rest of the tree, so the drift is visible in the
+        # log without anyone being forced to act on it. Drop continue-on-error
+        # once a reformatting pass has happened, and the check starts to mean
+        # something.
+        - name: Report formatting drift in the rest of the tree
+          run: black --check --diff .
+          continue-on-error: true
 
   test:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
Small one, and it is my fault rather than yours.

#87 and #78 both touched `.github/workflows/push.yaml`. You merged #87 at 14:55 and #78 at 15:15, both cleanly — but #78 was carrying its own, older copy of the `style` job, so the second merge quietly replaced what the first one had added. Git had no reason to complain: neither side conflicted, the later merge simply won.

**What was lost:** the repo-wide `black --check --diff .` report that #87 added.
**What survived:** `black --check tests/`, blocking.

This restores the first *alongside* the second instead of instead of it:

- `black --check tests/` stays exactly as it is, and stays blocking. Those files are already formatted, so keeping them that way is free.
- `black --check --diff .` is added back with `continue-on-error: true`. It prints exactly what black would change everywhere else, so the drift is visible in the log, but it can never fail the build.

The point of the second one is that it costs you nothing today and tells you something. Making it blocking would mean a whole-tree reformatting commit nobody asked for — so it does not, until you decide otherwise. The comment in the file says as much.

I should have spotted the overlap when I rebased #87 yesterday; I had aligned the two files the evening before, then extended #87 afterwards and did not re-align. Sorry for the extra round trip.